### PR TITLE
Pass in the app id from the sdk and then add it to fetch headers

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -40,6 +40,8 @@ export class CrossmintApiService implements XMIFService {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${jwt}`,
       'x-api-key': apiKey,
+			// When in a webview, we inject the crossmintAppId into the window object
+			"x-app-identifier": (window as any).crossmintAppId,
     };
   }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -35,14 +35,23 @@ export class CrossmintApiService implements XMIFService {
     return `${baseUrl}/${basePath}`;
   }
 
-  private getHeaders({ jwt, apiKey }: { jwt: string; apiKey: string }) {
-    return {
+  private getHeaders({ jwt, apiKey }: { jwt: string; apiKey: string }): Record<string, string> {
+    const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${jwt}`,
       'x-api-key': apiKey,
-			// When in a webview, we inject the crossmintAppId into the window object
-			"x-app-identifier": (window as any).crossmintAppId,
     };
+
+    // Add x-app-identifier only if running in a browser-like environment
+    // and the crossmintAppId is available on the window object.
+    if (typeof window !== 'undefined') {
+      const crossmintId = (window as WindowWithCrossmintAppId).crossmintAppId;
+      if (crossmintId != null) {
+        headers['x-app-identifier'] = crossmintId;
+      }
+    }
+
+    return headers;
   }
 
   /**
@@ -172,4 +181,8 @@ export function parseApiKey(apiKey: string): {
     origin,
     environment,
   };
+}
+
+interface WindowWithCrossmintAppId extends Window {
+  crossmintAppId?: string;
 }


### PR DESCRIPTION
Currently we pass in the api key in the header that needs to add the iframe domain as a whitelisted domain. Once that iframe is hosted by crossmint, and the frame is in an iframe, it should just work. But in a webview, it's loaded just like in a browser with no ancestor origins. 

We want to track what app made the request while also validating the api call, so the sdk will inject the appid into the webview, and that way the frame can add it to the request.