### PR TITLE
Bullet Proofing Part 1: Handle Device <> Auth Share Mismatches & Status Event (WAL-4558)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@crossmint/client-sdk-rn-window": "0.2.1",
     "@crossmint/client-sdk-window": "1.0.0",
-    "@crossmint/client-signers": "0.0.8",
+    "@crossmint/client-signers": "0.0.10",
     "@hpke/core": "^1.7.2",
     "@noble/ciphers": "^1.3.0",
     "bs58": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@crossmint/client-signers':
-        specifier: 0.0.8
-        version: 0.0.8
+        specifier: 0.0.10
+        version: 0.0.10
       '@hpke/core':
         specifier: ^1.7.2
         version: 1.7.2
@@ -59,7 +59,7 @@ importers:
         version: 8.30.1(eslint@9.25.0)(typescript@5.8.3)
       '@vitest/coverage-v8':
         specifier: ^3.1.1
-        version: 3.1.1(@vitest/browser@3.1.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)(vite@6.3.2(@types/node@20.17.30)(terser@5.39.0))(vitest@3.1.1))(vitest@3.1.1(@types/node@20.17.30)(@vitest/browser@3.1.1)(happy-dom@17.4.4)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.39.0))
+        version: 3.1.1(@vitest/browser@3.1.1)(vitest@3.1.1)
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -98,7 +98,7 @@ importers:
         version: 3.1.1(@types/node@20.17.30)(@vitest/browser@3.1.1)(happy-dom@17.4.4)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.39.0)
       vitest-mock-extended:
         specifier: ^3.1.0
-        version: 3.1.0(typescript@5.8.3)(vitest@3.1.1(@types/node@20.17.30)(@vitest/browser@3.1.1)(happy-dom@17.4.4)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.39.0))
+        version: 3.1.0(typescript@5.8.3)(vitest@3.1.1)
 
 packages:
 
@@ -275,8 +275,8 @@ packages:
   '@crossmint/client-sdk-window@1.0.0':
     resolution: {integrity: sha512-plzEzSYsJtQUpfyAVElWcUncp74/p1HI8aujH5f2FFdSbc85e3Q17TnQWRn9Gtj9KNpCuIsh36HCTMv8x5504g==}
 
-  '@crossmint/client-signers@0.0.8':
-    resolution: {integrity: sha512-9PjDp4iNQfQiBx3MQatC1unVg1GAUwHGxZubVkIGgUVVlXwpSq2A0rkaj9BEyJQawDN6xua6Yt6XH3UKR9BU4w==}
+  '@crossmint/client-signers@0.0.10':
+    resolution: {integrity: sha512-09mH2ZehUt/j4CrwYZEwBx4/mB8kv7Y4Ry/fAaj8NRgQPNDmSfspERvh0yroQ0uBn/AGYsNwIl0AYZDFxczY6g==}
 
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
@@ -3386,7 +3386,7 @@ snapshots:
     dependencies:
       zod: 3.22.4
 
-  '@crossmint/client-signers@0.0.8':
+  '@crossmint/client-signers@0.0.10':
     dependencies:
       zod: 3.22.4
 
@@ -4116,7 +4116,7 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.1.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)(vite@6.3.2(@types/node@20.17.30)(terser@5.39.0))(vitest@3.1.1))(vitest@3.1.1(@types/node@20.17.30)(@vitest/browser@3.1.1)(happy-dom@17.4.4)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.39.0))':
+  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.1.1)(vitest@3.1.1)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6263,7 +6263,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.39.0
 
-  vitest-mock-extended@3.1.0(typescript@5.8.3)(vitest@3.1.1(@types/node@20.17.30)(@vitest/browser@3.1.1)(happy-dom@17.4.4)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.39.0)):
+  vitest-mock-extended@3.1.0(typescript@5.8.3)(vitest@3.1.1):
     dependencies:
       ts-essentials: 10.0.4(typescript@5.8.3)
       typescript: 5.8.3

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -62,7 +62,7 @@ export class CrossmintApiService extends XMIFService {
   constructor(private readonly encryptionService: EncryptionService) {
     super();
     this.retryConfig = defaultRetryConfig;
-    this.environment = 'development'; // changed
+    this.environment = 'staging'; // TODO: Make this configurable
   }
 
   async init() {}
@@ -82,7 +82,6 @@ export class CrossmintApiService extends XMIFService {
       device: z.string(),
       auth: z.string(),
     }),
-    deviceKeyShareHash: z.string(),
   });
 
   static getAuthShardInputSchema = z.undefined();

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -62,7 +62,7 @@ export class CrossmintApiService extends XMIFService {
   constructor(private readonly encryptionService: EncryptionService) {
     super();
     this.retryConfig = defaultRetryConfig;
-    this.environment = 'staging'; // TODO: Make this configurable
+    this.environment = 'development'; // changed
   }
 
   async init() {}
@@ -82,12 +82,14 @@ export class CrossmintApiService extends XMIFService {
       device: z.string(),
       auth: z.string(),
     }),
+    deviceKeyShareHash: z.string(),
   });
 
   static getAuthShardInputSchema = z.undefined();
   static getAuthShardOutputSchema = z.object({
     deviceId: z.string(),
     keyShare: z.string(),
+    deviceKeyShareHash: z.string(),
   });
 
   static getAttestationInputSchema = z.undefined();

--- a/src/services/error.ts
+++ b/src/services/error.ts
@@ -1,0 +1,10 @@
+export type XMIFErrorCode = 'invalid-device-share';
+
+export class XMIFCodedError extends Error {
+  public readonly code: XMIFErrorCode;
+
+  constructor(message: string, code: XMIFErrorCode) {
+    super(message);
+    this.code = code;
+  }
+}

--- a/src/services/handlers.test.ts
+++ b/src/services/handlers.test.ts
@@ -3,10 +3,12 @@ import {
   CreateSignerEventHandler,
   SendOtpEventHandler,
   GetPublicKeyEventHandler,
+  SignEventHandler,
 } from './handlers';
 import { createMockServices } from '../tests/test-utils';
 import type { SignerInputEvent } from '@crossmint/client-signers';
 import bs58 from 'bs58';
+import { XMIFCodedError } from './error';
 
 const TEST_FIXTURES = {
   deviceId: 'test-device-id',
@@ -113,6 +115,44 @@ describe('EventHandlers', () => {
       );
       expect(mockServices.ed25519.getPublicKey).toHaveBeenCalledWith(TEST_FIXTURES.secretKey);
       expect(result).toEqual({ publicKey: TEST_FIXTURES.publicKey });
+    });
+  });
+
+  describe('SignEventHandler', () => {
+    it('should properly handle invalid device share errors', async () => {
+      // Create the handler directly like other tests
+      const handler = new SignEventHandler(mockServices);
+
+      // Setup the test data
+      const message = 'test message';
+      const encodedMessage = bs58.encode(Buffer.from(message));
+      const testInput: SignerInputEvent<'sign'> = {
+        authData: TEST_FIXTURES.authData,
+        data: {
+          keyType: 'ed25519',
+          bytes: encodedMessage,
+          encoding: 'base58',
+        },
+      };
+
+      // Mock the error that would be thrown when device share hash doesn't match
+      const mockError = new XMIFCodedError(
+        'Key share stored on this device does not match Crossmint held authentication share.',
+        'invalid-device-share'
+      );
+      mockServices.sharding.reconstructMasterSecret.mockRejectedValue(mockError);
+
+      // Test the whole event handler flow including error handling
+      const result = await handler.callback(testInput);
+
+      expect(mockServices.sharding.reconstructMasterSecret).toHaveBeenCalledWith(
+        testInput.authData
+      );
+      expect(result).toEqual({
+        status: 'error',
+        error: mockError.message,
+        code: 'invalid-device-share',
+      });
     });
   });
 });

--- a/src/services/handlers.test.ts
+++ b/src/services/handlers.test.ts
@@ -42,7 +42,7 @@ describe('EventHandlers', () => {
         data: { authId: 'test-auth-id', chainLayer: 'solana' },
       };
 
-      mockServices.sharding.getDeviceShare.mockReturnValue(TEST_FIXTURES.shares.device);
+      mockServices.sharding.status.mockReturnValue('ready');
 
       await handler.handler(testInput);
 
@@ -65,9 +65,10 @@ describe('EventHandlers', () => {
 
       mockServices.api.sendOtp.mockResolvedValue({
         shares: TEST_FIXTURES.shares,
+        deviceKeyShareHash: 'h(xyz)',
       });
 
-      mockServices.sharding.getMasterSecret.mockResolvedValue(TEST_FIXTURES.masterSecret);
+      mockServices.sharding.reconstructMasterSecret.mockResolvedValue(TEST_FIXTURES.masterSecret);
       mockServices.ed25519.secretKeyFromSeed.mockResolvedValue(TEST_FIXTURES.secretKey);
       mockServices.ed25519.getPublicKey.mockResolvedValue(
         bs58.encode(TEST_FIXTURES.secretKey.slice(32))
@@ -84,7 +85,6 @@ describe('EventHandlers', () => {
       expect(mockServices.sharding.storeDeviceShare).toHaveBeenCalledWith(
         TEST_FIXTURES.shares.device
       );
-      expect(mockServices.sharding.cacheAuthShare).toHaveBeenCalledWith(TEST_FIXTURES.shares.auth);
       expect(result).toHaveProperty('address');
     });
   });
@@ -99,13 +99,15 @@ describe('EventHandlers', () => {
         },
       };
 
-      mockServices.sharding.getMasterSecret.mockResolvedValue(TEST_FIXTURES.masterSecret);
+      mockServices.sharding.reconstructMasterSecret.mockResolvedValue(TEST_FIXTURES.masterSecret);
       mockServices.ed25519.secretKeyFromSeed.mockResolvedValue(TEST_FIXTURES.secretKey);
       mockServices.ed25519.getPublicKey.mockResolvedValue(TEST_FIXTURES.publicKey);
 
       const result = await handler.handler(testInput);
 
-      expect(mockServices.sharding.getMasterSecret).toHaveBeenCalledWith(testInput.authData);
+      expect(mockServices.sharding.reconstructMasterSecret).toHaveBeenCalledWith(
+        testInput.authData
+      );
       expect(mockServices.ed25519.secretKeyFromSeed).toHaveBeenCalledWith(
         TEST_FIXTURES.masterSecret
       );

--- a/src/services/handlers.ts
+++ b/src/services/handlers.ts
@@ -6,22 +6,22 @@ import type {
 import bs58 from 'bs58';
 import type { XMIFServices } from '.';
 import { measureFunctionTime } from './utils';
+import { XMIFCodedError } from './error';
+
 const DEFAULT_TIMEOUT_MS = 30_000;
 
-export interface EventHandler<EventName extends SignerIFrameEventName = SignerIFrameEventName> {
-  event: `request:${EventName}`;
-  responseEvent: `response:${EventName}`;
-  handler: (
-    payload: SignerInputEvent<EventName>
-  ) => Promise<Omit<SignerOutputEvent<EventName>, 'status'>>;
-  callback: (payload: SignerInputEvent<EventName>) => Promise<SignerOutputEvent<EventName>>;
-}
-abstract class BaseEventHandler<EventName extends SignerIFrameEventName = SignerIFrameEventName> {
+export abstract class EventHandler<
+  EventName extends SignerIFrameEventName = SignerIFrameEventName,
+> {
   abstract event: `request:${EventName}`;
   abstract responseEvent: `response:${EventName}`;
+
   abstract handler(
     payload: SignerInputEvent<EventName>
   ): Promise<Omit<SignerOutputEvent<EventName>, 'status'>>;
+
+  constructor(protected readonly services: XMIFServices) {}
+
   async callback(payload: SignerInputEvent<EventName>): Promise<SignerOutputEvent<EventName>> {
     try {
       const result = await measureFunctionTime(`[${this.event} handler]`, async () =>
@@ -32,83 +32,65 @@ abstract class BaseEventHandler<EventName extends SignerIFrameEventName = Signer
         ...result,
       };
     } catch (error: unknown) {
-      console.error(`[${this.event} handler] Error: ${error}`);
-      return {
-        status: 'error',
+      const errorResponse = {
+        status: 'error' as const,
         error: error instanceof Error ? error.message : 'Unknown error',
+        ...(error instanceof XMIFCodedError && { code: error.code }),
       };
+
+      console.error(`[${this.event} handler] Error: ${error}`);
+      return errorResponse;
     }
   }
+
   options = {
     timeoutMs: DEFAULT_TIMEOUT_MS,
   };
 }
 
-export class CreateSignerEventHandler extends BaseEventHandler<'create-signer'> {
-  constructor(
-    services: XMIFServices,
-    private readonly api = services.api,
-    private readonly shardingService = services.sharding,
-    private readonly ed25519Service = services.ed25519,
-    private readonly encryptionService = services.encrypt
-  ) {
-    super();
-  }
+export class CreateSignerEventHandler extends EventHandler<'create-signer'> {
   event = 'request:create-signer' as const;
   responseEvent = 'response:create-signer' as const;
-  async handler(payload: SignerInputEvent<'create-signer'>) {
-    if (!this.api) {
-      throw new Error('API service is not available');
-    }
 
-    if (this.shardingService.getDeviceShare() != null) {
-      const masterSecret = await this.shardingService.getMasterSecret(payload.authData);
-      const publicKey = await this.ed25519Service.getPublicKey(masterSecret);
+  async handler(payload: SignerInputEvent<'create-signer'>) {
+    if (this.services.sharding.status() === 'ready') {
+      const masterSecret = await this.services.sharding.reconstructMasterSecret(payload.authData);
+      const publicKey = await this.services.ed25519.getPublicKey(masterSecret);
       return {
         address: publicKey,
       };
     }
 
-    console.log('Signer not yet initialized, creating a new one...');
-    const deviceId = this.shardingService.getDeviceId();
-    await this.api.createSigner(
-      deviceId,
+    await this.services.api.createSigner(
+      this.services.sharding.getDeviceId(),
       {
         ...payload.data,
         encryptionContext: {
-          publicKey: await this.encryptionService.getPublicKey(),
+          publicKey: await this.services.encrypt.getPublicKey(),
         },
       },
       payload.authData
     );
+
     return {};
   }
 }
 
-export class SendOtpEventHandler extends BaseEventHandler<'send-otp'> {
-  constructor(
-    services: XMIFServices,
-    private readonly api = services.api,
-    private readonly shardingService = services.sharding,
-    private readonly ed25519Service = services.ed25519,
-    private readonly encryptionService = services.encrypt,
-    private readonly fpeService = services.fpe
-  ) {
-    super();
-  }
+export class SendOtpEventHandler extends EventHandler<'send-otp'> {
   event = 'request:send-otp' as const;
   responseEvent = 'response:send-otp' as const;
-  handler = async (payload: SignerInputEvent<'send-otp'>) => {
-    const deviceId = this.shardingService.getDeviceId();
+
+  async handler(payload: SignerInputEvent<'send-otp'>) {
+    const deviceId = this.services.sharding.getDeviceId();
     console.log(
       `[DEBUG, ${this.event} handler] Received encrypted OTP: ${payload.data.encryptedOtp}. Decrypting`
     );
     const decryptedOtp = (
-      await this.fpeService.decrypt(payload.data.encryptedOtp.split('').map(Number))
+      await this.services.fpe.decrypt(payload.data.encryptedOtp.split('').map(Number))
     ).join('');
-    console.log(`[DEBUG, ${this.event} handler] Decrypted OTP: ${decryptedOtp}.`);
-    const senderPublicKey = await this.encryptionService.getPublicKey();
-    const response = await this.api.sendOtp(
+    const senderPublicKey = await this.services.encrypt.getPublicKey();
+
+    const response = await this.services.api.sendOtp(
       deviceId,
       {
         otp: decryptedOtp,
@@ -117,63 +99,59 @@ export class SendOtpEventHandler extends BaseEventHandler<'send-otp'> {
       payload.authData
     );
 
-    this.shardingService.storeDeviceShare(response.shares.device);
-    this.shardingService.cacheAuthShare(response.shares.auth);
-
-    const masterSecret = await this.shardingService.getMasterSecret(payload.authData);
-    const secretKey = await this.ed25519Service.secretKeyFromSeed(masterSecret);
-    const publicKey = await this.ed25519Service.getPublicKey(secretKey);
+    this.services.sharding.storeDeviceShare(response.shares.device);
+    const masterSecret = await this.services.sharding.reconstructMasterSecret(payload.authData);
+    const secretKey = await this.services.ed25519.secretKeyFromSeed(masterSecret);
+    const publicKey = await this.services.ed25519.getPublicKey(secretKey);
     return {
       address: publicKey,
     };
-  };
+  }
 }
 
-export class GetPublicKeyEventHandler extends BaseEventHandler<'get-public-key'> {
-  constructor(
-    services: XMIFServices,
-    private readonly shardingService = services.sharding,
-    private readonly ed25519Service = services.ed25519
-  ) {
-    super();
-  }
+export class GetPublicKeyEventHandler extends EventHandler<'get-public-key'> {
   event = 'request:get-public-key' as const;
   responseEvent = 'response:get-public-key' as const;
-  handler = async (payload: SignerInputEvent<'get-public-key'>) => {
-    const masterSecret = await this.shardingService.getMasterSecret(payload.authData);
-    const secretKey = await this.ed25519Service.secretKeyFromSeed(masterSecret);
-    const publicKey = await this.ed25519Service.getPublicKey(secretKey);
+
+  async handler(payload: SignerInputEvent<'get-public-key'>) {
+    const masterSecret = await this.services.sharding.reconstructMasterSecret(payload.authData);
+    const secretKey = await this.services.ed25519.secretKeyFromSeed(masterSecret);
+    const publicKey = await this.services.ed25519.getPublicKey(secretKey);
     return {
       publicKey,
     };
-  };
-}
-class SignEventHandler extends BaseEventHandler<'sign'> {
-  constructor(
-    services: XMIFServices,
-    private readonly shardingService = services.sharding,
-    private readonly edd25519Service = services.ed25519
-  ) {
-    super();
   }
+}
+
+export class GetStatusEventHandler extends EventHandler<'get-status'> {
+  event = 'request:get-status' as const;
+  responseEvent = 'response:get-status' as const;
+
+  async handler() {
+    return { signerStatus: this.services.sharding.status() };
+  }
+}
+
+class SignEventHandler extends EventHandler<'sign'> {
   event = 'request:sign' as const;
   responseEvent = 'response:sign' as const;
-  handler = async (payload: SignerInputEvent<'sign'>) => {
-    const masterSecret = await this.shardingService.getMasterSecret(payload.authData);
+
+  async handler(payload: SignerInputEvent<'sign'>) {
+    const masterSecret = await this.services.sharding.reconstructMasterSecret(payload.authData);
     const { keyType, bytes, encoding } = payload.data;
     switch (keyType) {
       case 'ed25519': {
         const message = decodeBytes(bytes, encoding);
-        const secretKey = await this.edd25519Service.secretKeyFromSeed(masterSecret);
+        const secretKey = await this.services.ed25519.secretKeyFromSeed(masterSecret);
         return {
-          signature: bs58.encode(await this.edd25519Service.sign(message, secretKey)),
-          publicKey: await this.edd25519Service.getPublicKey(secretKey),
+          signature: bs58.encode(await this.services.ed25519.sign(message, secretKey)),
+          publicKey: await this.services.ed25519.getPublicKey(secretKey),
         };
       }
       default:
         throw new Error(`Key type not implemented: ${keyType}`);
     }
-  };
+  }
 }
 
 function decodeBytes(bytes: string, encoding: 'base64' | 'base58'): Uint8Array {
@@ -190,4 +168,5 @@ export const initializeHandlers = (services: XMIFServices) => [
   new CreateSignerEventHandler(services),
   new GetPublicKeyEventHandler(services),
   new SignEventHandler(services),
+  new GetStatusEventHandler(services),
 ];

--- a/src/services/handlers.ts
+++ b/src/services/handlers.ts
@@ -132,7 +132,7 @@ export class GetStatusEventHandler extends EventHandler<'get-status'> {
   }
 }
 
-class SignEventHandler extends EventHandler<'sign'> {
+export class SignEventHandler extends EventHandler<'sign'> {
   event = 'request:sign' as const;
   responseEvent = 'response:sign' as const;
 

--- a/src/services/sharding.ts
+++ b/src/services/sharding.ts
@@ -1,9 +1,11 @@
 import { combine } from 'shamir-secret-sharing';
 import { XMIFService } from './service';
 import type { CrossmintApiService } from './api';
+import { XMIFCodedError } from './error';
 
-const AUTH_SHARE_KEY = 'auth-share';
 const DEVICE_SHARE_KEY = 'device-share';
+const DEVICE_ID_KEY = 'device-id';
+const HASH_ALGO = 'SHA-256';
 
 // Chain agnostic secret sharding service
 export class ShardingService extends XMIFService {
@@ -19,7 +21,7 @@ export class ShardingService extends XMIFService {
   public getDeviceId(): string {
     this.log('Attempting to get device ID from storage');
 
-    const existing = localStorage.getItem('deviceId');
+    const existing = localStorage.getItem(DEVICE_ID_KEY);
     if (existing != null) {
       this.log(`Found existing device ID: ${existing.substring(0, 8)}...`);
       return existing;
@@ -27,28 +29,39 @@ export class ShardingService extends XMIFService {
 
     this.log('No existing device ID found, generating new one');
     const deviceId = crypto.randomUUID();
-    localStorage.setItem('deviceId', deviceId);
+    localStorage.setItem(DEVICE_ID_KEY, deviceId);
     this.log(`Successfully stored new device ID: ${deviceId.substring(0, 8)}...`);
     return deviceId;
   }
 
-  public async getMasterSecret(authData: { jwt: string; apiKey: string }) {
-    const deviceShare = this.getDeviceShare();
-    if (!deviceShare) {
+  public async reconstructMasterSecret(authData: { jwt: string; apiKey: string }) {
+    const deviceShare = localStorage.getItem(DEVICE_SHARE_KEY);
+    if (deviceShare == null) {
       throw new Error('Device share not found');
     }
 
-    let authShare = this.getCachedAuthShare();
-    if (!authShare) {
-      this.log('Auth share not found in cache, fetching from API');
-      const deviceId = this.getDeviceId();
-      const { keyShare } = await this.api.getAuthShard(deviceId, undefined, authData);
-      this.cacheAuthShare(keyShare);
-      authShare = keyShare;
+    const deviceShareBytes = this.base64ToBytes(deviceShare);
+
+    const { keyShare: authShare, deviceKeyShareHash: expectedDeviceHashBase64 } =
+      await this.api.getAuthShard(this.getDeviceId(), undefined, authData);
+
+    const hashBuffer = await crypto.subtle.digest(HASH_ALGO, deviceShareBytes);
+    const currentHashBase64 = this.bytesToBase64(new Uint8Array(hashBuffer));
+
+    if (currentHashBase64 !== expectedDeviceHashBase64) {
+      localStorage.removeItem(DEVICE_SHARE_KEY);
+      localStorage.removeItem(DEVICE_ID_KEY);
+      throw new XMIFCodedError(
+        `Key share stored on this device does not match Crossmint held authentication share.\n` +
+          `Actual hash of local device share: ${currentHashBase64}\n` +
+          `Expected hash from Crossmint: ${expectedDeviceHashBase64}`,
+        'invalid-device-share'
+      );
     }
 
     try {
-      return await combine([this.base64ToBytes(deviceShare), this.base64ToBytes(authShare)]);
+      const authShareBytes = this.base64ToBytes(authShare);
+      return await combine([deviceShareBytes, authShareBytes]);
     } catch (error) {
       throw new Error(
         `Failed to recombine key shards: ${error instanceof Error ? error.message : String(error)}`
@@ -56,24 +69,23 @@ export class ShardingService extends XMIFService {
     }
   }
 
-  storeDeviceShare(share: string): void {
+  public storeDeviceShare(share: string): void {
     localStorage.setItem(DEVICE_SHARE_KEY, share);
   }
 
-  // TODO: implement cache
-  cacheAuthShare(share: string): void {
-    sessionStorage.setItem(AUTH_SHARE_KEY, share);
-  }
+  public status(): 'ready' | 'new-device' {
+    if (localStorage.getItem(DEVICE_SHARE_KEY) == null) {
+      return 'new-device';
+    }
 
-  getDeviceShare(): string | null {
-    return localStorage.getItem(DEVICE_SHARE_KEY);
-  }
-
-  getCachedAuthShare(): string | null {
-    return sessionStorage.getItem(AUTH_SHARE_KEY);
+    return 'ready';
   }
 
   private base64ToBytes(base64: string): Uint8Array {
     return Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+  }
+
+  private bytesToBase64(bytes: Uint8Array): string {
+    return btoa(String.fromCharCode.apply(null, Array.from(bytes)));
   }
 }


### PR DESCRIPTION
## Description

This PR is the first in a series to make the iframe more resilient.

### Device <> Auth Key Share Mismatch Handling

Device and auth key share mismatches can occur in many different ways:
- multiple users using the same device (will be handled better later by having user and app specific keyed storage)
- tampering with the device share
- etc
Left unhandled, they cause signing to fail in an opaque way. This PR fixes that.

To run checks against this, with each auth key share Crossmint stores the hash of the associated device share. PRs to add this:
- [TEE PR](https://github.com/Paella-Labs/tee-ts/pull/7)
- [Crossmint Main Service PR](https://github.com/Paella-Labs/crossbit-main/pull/18850)

At signing time, after fetching the auth share from Crossmint, to detect when the two key shares don't match the iframe hashes the current device key share and checks it against the hash returned by Crossmint. To simplify this process for now, this PR also makes the iframe fetch the auth share for each signature, our caching strategy for that is TBD.

If there's a mismatch, the `request:sign` event responds with:
```JSON
{
    "status": "error",
    "message": "<details about mismatch for debugging>",
    "code": "invalid-device-share"
}
```

At which point our Wallet SDKs can decide how to proceed. Here's a [React SDK PR](https://github.com/Crossmint/crossmint-sdk/pull/1121) that handles this case by sending the user through device setup again (for now the OTP flow).

### Get Status Event

This PR also introduces a new event: `get-status`. It responds with `ready` if the device holds a key share, or `new-device` if not. That's how `get-public-key` is currently being used, and with the auth share being fetched every time we reconstruct the key for now, this simpler method avoids that and is more idiomatic.

## Testing

### Unit tests

This PR adds sharding service and `sign` handler unit tests for the device hash mismatch case.

### Local testing

I have the quickstart demo running locally in the SDK workspace. (will add this in a separate PR)

With changes from this PR and the other three mentioned above all running in unison, locally I tested the following flow:
- log in and go through the OTP flow to sign a transaction on a new device.
- modify the device key share hash Crossmint stores in the database associated with the new device
- send another transaction
- see that it fails with the error code `invalid-device-share`, and the SDK routes me through the OTP flow again
- The transaction is successfully sent.

PS. we'll iterate on the internal developer experience working on this feature, running 4 different codebases at once is painful XD.
