### PR TITLE
Make environment configurable [WAL-4579]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@
  */
 
 import { initializeHandlers, createXMIFServices } from './services';
-import type { Environment } from './services/api';
 import type { EventHandler } from './services/handlers';
 import { measureFunctionTime } from './services/utils';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { initializeHandlers, createXMIFServices } from './services';
+import type { Environment } from './services/api';
 import type { EventHandler } from './services/handlers';
 import { measureFunctionTime } from './services/utils';
 
@@ -20,7 +21,7 @@ declare global {
 class XMIF {
   private static instance: XMIF | null = null;
   private static initializationPromise: Promise<XMIF> | null = null;
-  constructor(
+  private constructor(
     private readonly services = createXMIFServices(),
     private readonly handlers = initializeHandlers(services) as EventHandler[]
   ) {}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -8,7 +8,12 @@ import type { RetryConfig } from './backoff';
 import { z } from 'zod';
 import type { EncryptionService } from './encryption';
 import { type AuthData, CrossmintRequest } from './request';
+
 export type Environment = 'development' | 'staging' | 'production';
+const DEFAULT_ENVIRONMENT: Environment = 'staging';
+const isEnvironment = (env: unknown): env is Environment => {
+  return ['development', 'staging', 'production'].includes(env as Environment);
+};
 
 function getHeaders(authData?: AuthData) {
   return {
@@ -62,7 +67,16 @@ export class CrossmintApiService extends XMIFService {
   constructor(private readonly encryptionService: EncryptionService) {
     super();
     this.retryConfig = defaultRetryConfig;
-    this.environment = 'staging'; // TODO: Make this configurable
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const envParam = urlParams.get('environment');
+    if (isEnvironment(envParam)) {
+      this.log(`Environment: ${envParam}`);
+      this.environment = envParam;
+    } else {
+      this.log(`Using default environment: ${DEFAULT_ENVIRONMENT}`);
+      this.environment = DEFAULT_ENVIRONMENT;
+    }
   }
 
   async init() {}


### PR DESCRIPTION
For certain API calls we don't have an API key that we can use to infer the environment, so we need to pass it somehow. Here we add a query param for that