### PR TITLE
NCS: enable key exports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html/dist
 COPY --from=builder /app/css /usr/share/nginx/html/css
 COPY --from=builder /app/index.html /usr/share/nginx/html/
+COPY --from=builder /app/export.html /usr/share/nginx/html/
 COPY --from=builder /app/favicon.ico /usr/share/nginx/html/
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -297,14 +297,16 @@ button:disabled {
 .action-button {
     margin-right: 5px;
     cursor: pointer;
-    background-color: #f2f2f2;
+    background-color: #3498db;
+    color: white;
     border: none;
-    padding: 3px 8px;
-    border-radius: 3px;
+    padding: 8px 15px;
+    border-radius: 4px;
+    transition: background-color 0.3s;
 }
 
 .action-button:hover {
-    background-color: #e0e0e0;
+    background-color: #2980b9;
 }
 
 .delete-button {
@@ -368,4 +370,94 @@ button:disabled {
 
 .storage-cleanup-btn:active {
     transform: scale(0.95);
+}
+
+/* Export Page Specific Styles */
+.export-keys-textarea {
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-size: 12px;
+    background-color: #f8f9fa;
+    border: 2px dashed #dee2e6;
+    resize: vertical;
+    transition: border-color 0.3s ease;
+}
+
+.export-keys-textarea:focus {
+    border-color: #3498db;
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+}
+
+.export-keys-textarea.has-content {
+    border-style: solid;
+    border-color: #28a745;
+    background-color: #f8fff9;
+}
+
+.architecture-select {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
+    font-family: inherit;
+    background-color: white;
+    transition: border-color 0.3s ease;
+}
+
+.architecture-select:focus {
+    border-color: #3498db;
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+}
+
+.export-status {
+    margin-top: 15px;
+    padding: 10px;
+    border-radius: 4px;
+    font-weight: 500;
+    transition: all 0.3s ease;
+}
+
+.export-status.success {
+    background-color: #d4edda;
+    border: 1px solid #c3e6cb;
+    color: #155724;
+}
+
+.export-status.error {
+    background-color: #f8d7da;
+    border: 1px solid #f5c6cb;
+    color: #721c24;
+}
+
+.export-status.info {
+    background-color: #d1ecf1;
+    border: 1px solid #bee5eb;
+    color: #0c5460;
+}
+
+.copy-success {
+    animation: copySuccess 0.3s ease;
+}
+
+@keyframes copySuccess {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+    100% { transform: scale(1); }
+}
+
+.export-warning {
+    background-color: #fff3cd;
+    border: 1px solid #ffeaa7;
+    color: #856404;
+    padding: 12px;
+    border-radius: 4px;
+    margin-bottom: 15px;
+    font-size: 0.9em;
+}
+
+.export-warning::before {
+    content: "⚠️ ";
+    font-weight: bold;
 } 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,3 +1,414 @@
+/* Professional Export Page Styles */
+
+/* Reset and base styles */
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #333;
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 16px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Professional Header */
+.professional-header {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    border-radius: 12px;
+    padding: 16px 24px;
+    margin-bottom: 20px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.header-content {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.header-icon {
+    width: 40px;
+    height: 40px;
+    background: linear-gradient(135deg, #3498db, #2980b9);
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    flex-shrink: 0;
+}
+
+.header-text h1 {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 700;
+    color: #2c3e50;
+    letter-spacing: -0.5px;
+}
+
+.header-subtitle {
+    margin: 2px 0 0 0;
+    font-size: 14px;
+    color: #64748b;
+    font-weight: 400;
+}
+
+/* Main Content */
+.main-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.export-card {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    overflow: hidden;
+    flex: 1;
+}
+
+.card-header {
+    background: linear-gradient(135deg, #f8fafc, #e2e8f0);
+    padding: 20px 24px;
+    border-bottom: 1px solid rgba(226, 232, 240, 0.5);
+}
+
+.card-header h2 {
+    margin: 0 0 4px 0;
+    font-size: 20px;
+    font-weight: 600;
+    color: #1e293b;
+    letter-spacing: -0.3px;
+}
+
+.card-description {
+    margin: 0;
+    font-size: 14px;
+    color: #64748b;
+}
+
+/* Loading Section */
+.loading-section {
+    padding: 40px 24px;
+    text-align: center;
+}
+
+.loading-content h3 {
+    margin: 16px 0 8px 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #334155;
+}
+
+.loading-content p {
+    margin: 0;
+    font-size: 14px;
+    color: #64748b;
+}
+
+.loading-spinner {
+    width: 36px;
+    height: 36px;
+    border: 3px solid #e2e8f0;
+    border-top: 3px solid #3498db;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 16px auto;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* Export Section */
+.export-section {
+    padding: 20px 24px;
+}
+
+
+
+/* Security Notice */
+.security-notice {
+    display: flex;
+    gap: 12px;
+    background: linear-gradient(135deg, #fef3c7, #fde68a);
+    border: 1px solid #f59e0b;
+    border-radius: 8px;
+    padding: 16px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+
+.notice-icon {
+    font-size: 20px;
+    flex-shrink: 0;
+}
+
+.notice-content strong {
+    display: block;
+    font-size: 14px;
+    font-weight: 600;
+    color: #92400e;
+    margin-bottom: 2px;
+}
+
+.notice-content p {
+    margin: 0;
+    font-size: 13px;
+    color: #a16207;
+    line-height: 1.4;
+}
+
+/* Form Section */
+.form-section {
+    max-width: 100%;
+}
+
+.form-group {
+    margin-bottom: 16px;
+}
+
+.form-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+    font-weight: 600;
+    font-size: 14px;
+    color: #374151;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.label-icon {
+    font-size: 16px;
+}
+
+.form-select {
+    width: 100%;
+    padding: 12px 16px;
+    border: 2px solid #e5e7eb;
+    border-radius: 8px;
+    font-size: 16px;
+    background: white;
+    transition: all 0.2s ease;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3e%3c/svg%3e");
+    background-position: right 12px center;
+    background-repeat: no-repeat;
+    background-size: 16px;
+    padding-right: 48px;
+}
+
+.form-select:focus {
+    outline: none;
+    border-color: #3498db;
+    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+}
+
+.form-select:disabled {
+    background-color: #f9fafb;
+    color: #9ca3af;
+    cursor: not-allowed;
+}
+
+/* Key Display Grid */
+.key-display-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+@media (max-width: 768px) {
+    .key-display-grid {
+        grid-template-columns: 1fr;
+        gap: 20px;
+    }
+}
+
+.key-group {
+    display: flex;
+    flex-direction: column;
+}
+
+.key-textarea {
+    width: 100%;
+    min-height: 160px;
+    padding: 12px;
+    border: 2px solid #e5e7eb;
+    border-radius: 6px;
+    font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+    font-size: 12px;
+    line-height: 1.4;
+    background: #f8fafc;
+    resize: vertical;
+    transition: all 0.2s ease;
+}
+
+.key-textarea:focus {
+    outline: none;
+    border-color: #3498db;
+    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+    background: white;
+}
+
+/* Button Group */
+.button-group {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+}
+
+@media (max-width: 640px) {
+    .button-group {
+        flex-direction: column;
+    }
+}
+
+/* Button Styles */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 16px;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none !important;
+}
+
+.btn-icon {
+    font-size: 16px;
+}
+
+.btn-primary {
+    background: linear-gradient(135deg, #3498db, #2980b9);
+    color: white;
+    box-shadow: 0 4px 12px rgba(52, 152, 219, 0.3);
+}
+
+.btn-primary:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(52, 152, 219, 0.4);
+}
+
+.btn-secondary {
+    background: linear-gradient(135deg, #10b981, #059669);
+    color: white;
+    box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+}
+
+.btn-secondary:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(16, 185, 129, 0.4);
+}
+
+.btn-outline {
+    background: white;
+    color: #6b7280;
+    border: 2px solid #e5e7eb;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.btn-outline:hover:not(:disabled) {
+    background: #f9fafb;
+    border-color: #d1d5db;
+    transform: translateY(-1px);
+}
+
+/* Status Message */
+.status-message {
+    padding: 16px 20px;
+    border-radius: 8px;
+    font-weight: 500;
+    text-align: center;
+}
+
+.status-message.success {
+    background: linear-gradient(135deg, #d1fae5, #a7f3d0);
+    border: 1px solid #10b981;
+    color: #065f46;
+}
+
+.status-message.error {
+    background: linear-gradient(135deg, #fee2e2, #fecaca);
+    border: 1px solid #ef4444;
+    color: #991b1b;
+}
+
+.status-message.info {
+    background: linear-gradient(135deg, #dbeafe, #bfdbfe);
+    border: 1px solid #3b82f6;
+    color: #1e40af;
+}
+
+/* Professional Footer */
+.professional-footer {
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(10px);
+    border-radius: 12px;
+    padding: 16px 24px;
+    margin-top: 20px;
+    text-align: center;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.footer-content p:first-child {
+    margin: 0 0 4px 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: white;
+}
+
+.footer-description {
+    margin: 0;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+/* Copy Success Animation */
+.copy-success {
+    animation: copySuccess 0.3s ease;
+}
+
+@keyframes copySuccess {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+    100% { transform: scale(1); }
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
     margin: 0;
@@ -435,16 +846,6 @@ button:disabled {
     background-color: #d1ecf1;
     border: 1px solid #bee5eb;
     color: #0c5460;
-}
-
-.copy-success {
-    animation: copySuccess 0.3s ease;
-}
-
-@keyframes copySuccess {
-    0% { transform: scale(1); }
-    50% { transform: scale(1.05); }
-    100% { transform: scale(1); }
 }
 
 .export-warning {

--- a/export.html
+++ b/export.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+
+    <title>🔑 Crossmint Key Export</title>
+    <link rel="stylesheet" href="css/styles.css">
+    <script src="dist/bundle.min.js"></script>
+    <style>
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+    </style>
+    
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>🔑 Crossmint Key Exporter</h1>
+        </header>
+        <!-- <div class="status-container">
+            <div class="status" id="status">Loaded. Waiting for parent handshake...</div>
+        </div> -->
+        
+        <div class="demo-section">
+            <h2>🔐 Private Key Export</h2>
+            
+            <!-- Loading state -->
+            <div id="loading-state">
+                <div class="loading-container" style="text-align: center; padding: 40px;">
+                    <div class="loading-spinner" style="display: inline-block; width: 40px; height: 40px; border: 4px solid #f3f3f3; border-top: 4px solid #007bff; border-radius: 50%; animation: spin 1s linear infinite; margin-bottom: 20px;"></div>
+                    <p style="font-size: 18px; color: #666;">Exporting keys...</p>
+                    <p style="font-size: 14px; color: #999;">Waiting for keys from parent application</p>
+                </div>
+            </div>
+            
+            <!-- Export interface (hidden initially) -->
+            <div id="export-interface" style="display: none;">
+                <p>Select a key type to display the corresponding private key.</p>
+                
+                <div class="export-warning">
+                    <strong>Security Notice:</strong> Private keys are extremely sensitive. Only export keys in a secure environment and never share them publicly or store them in unsecured locations.
+                </div>
+                
+                <div class="form-group">
+                    <label for="key-type-select">Select Key Type:</label>
+                    <select id="key-type-select" class="architecture-select" disabled>
+                        <option value="">Waiting for keys from parent...</option>
+                    </select>
+                </div>
+                
+                <div class="form-group">
+                    <label for="private-keys-display">Private Key:</label>
+                    <textarea 
+                        id="private-keys-display" 
+                        readonly 
+                        placeholder="Waiting for keys from parent application..."
+                        class="export-keys-textarea"
+                        style="min-height: 200px;"
+                    ></textarea>
+                </div>
+                
+                <div class="form-group">
+                    <label for="public-keys-display">Public Key:</label>
+                    <textarea 
+                        id="public-keys-display" 
+                        readonly 
+                        placeholder="Public key will be displayed here..."
+                        class="export-keys-textarea"
+                        style="min-height: 200px;"
+                    ></textarea>
+                </div>
+                
+                <div class="form-group">
+                    <button id="copy-private-btn" class="action-button" disabled>📋 Copy Private Key</button>
+                    <button id="copy-public-btn" class="action-button" disabled>📋 Copy Public Key</button>
+                    <button id="clear-btn" class="action-button">🗑️ Clear Display</button>
+                </div>
+                
+                <div id="export-status" class="status" style="display: none; margin-top: 15px;"></div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="footer">
+        Crossmint Key Export
+        <p class="footer-note">This secure environment runs in an isolated iframe, providing a protected vault for your key export operations.</p>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const keyTypeSelect = document.getElementById('key-type-select');
+            const copyPrivateBtn = document.getElementById('copy-private-btn');
+            const copyPublicBtn = document.getElementById('copy-public-btn');
+            const clearBtn = document.getElementById('clear-btn');
+            const privateKeysDisplay = document.getElementById('private-keys-display');
+            const publicKeysDisplay = document.getElementById('public-keys-display');
+            const exportStatus = document.getElementById('export-status');
+            const loadingState = document.getElementById('loading-state');
+            const exportInterface = document.getElementById('export-interface');
+            
+            // Listen for keys received from ExportsService
+            window.addEventListener('xmif:keys-received', (event) => {
+                const { keyTypes } = event.detail;
+                
+                // Hide loading state and show export interface
+                loadingState.style.display = 'none';
+                exportInterface.style.display = 'block';
+                
+                populateKeyTypeSelect(keyTypes);
+                updateStatus('✅ Keys received from parent application. Select a key type to display.', 'success');
+            });
+
+            // Listen for keys cleared from ExportsService
+            window.addEventListener('xmif:keys-cleared', () => {
+                // Show loading state and hide export interface
+                loadingState.style.display = 'block';
+                exportInterface.style.display = 'none';
+                
+                clearKeyTypeSelect();
+                updateStatus('Keys cleared', 'info');
+            });
+            
+            // Key type selection handler
+            keyTypeSelect.addEventListener('change', () => {
+                const selectedKeyType = keyTypeSelect.value;
+                if (selectedKeyType && window.XMIF?.services?.exports) {
+                    window.XMIF.services.exports.showKeyType(selectedKeyType);
+                }
+            });
+            
+            // Copy private key button handler
+            copyPrivateBtn.addEventListener('click', async () => {
+                try {
+                    await navigator.clipboard.writeText(privateKeysDisplay.value);
+                    showCopySuccess(copyPrivateBtn, 'Private key copied!');
+                } catch (error) {
+                    console.error('Failed to copy private key to clipboard:', error);
+                    // Fallback for older browsers
+                    privateKeysDisplay.select();
+                    document.execCommand('copy');
+                    showCopySuccess(copyPrivateBtn, 'Private key copied!');
+                }
+            });
+
+            // Copy public key button handler
+            copyPublicBtn.addEventListener('click', async () => {
+                try {
+                    await navigator.clipboard.writeText(publicKeysDisplay.value);
+                    showCopySuccess(copyPublicBtn, 'Public key copied!');
+                } catch (error) {
+                    console.error('Failed to copy public key to clipboard:', error);
+                    // Fallback for older browsers
+                    publicKeysDisplay.select();
+                    document.execCommand('copy');
+                    showCopySuccess(copyPublicBtn, 'Public key copied!');
+                }
+            });
+            
+            // Clear button handler
+            clearBtn.addEventListener('click', () => {
+                if (window.XMIF?.services?.exports) {
+                    window.XMIF.services.exports.clear();
+                }
+            });
+
+            function populateKeyTypeSelect(keyTypes) {
+                keyTypeSelect.innerHTML = '<option value="">Select a key type...</option>';
+                keyTypes.forEach(keyType => {
+                    const option = document.createElement('option');
+                    option.value = keyType;
+                    option.textContent = keyType.toUpperCase();
+                    keyTypeSelect.appendChild(option);
+                });
+                keyTypeSelect.disabled = false;
+            }
+
+            function clearKeyTypeSelect() {
+                keyTypeSelect.innerHTML = '<option value="">Waiting for keys from parent...</option>';
+                keyTypeSelect.disabled = true;
+            }
+
+            function updateStatus(message, type) {
+                if (exportStatus) {
+                    exportStatus.style.display = 'block';
+                    exportStatus.textContent = message;
+                    exportStatus.className = `export-status ${type}`;
+                }
+            }
+
+            function showCopySuccess(button, message = '✅ Copied!') {
+                const originalText = button.textContent;
+                button.textContent = message;
+                button.classList.add('copy-success');
+                setTimeout(() => {
+                    button.textContent = originalText;
+                    button.classList.remove('copy-success');
+                }, 2000);
+            }
+
+          
+                
+            
+            // Initialize XMIF
+            if (window.XMIF) {
+                (async () => {
+                await new Promise(resolve => setTimeout(resolve, 5000));
+                window.XMIF.services.exports.setExportedKeys({
+                    'secp256k1': {
+                        privateKey: '0x1234567890abcdefbutlonger',
+                        publicKey: '0x1234567890abcdef'
+                    },
+                    'ed25519': {
+                        privateKey: 'dfwftyftyhgvddcgshxhdfasghfjk',
+                        publicKey: 'dfwftyftyhgvd'
+                    }
+                });
+            })();
+                window.XMIF.init()
+                    .then(() => {
+                        console.log('XMIF framework initialized');
+                        document.getElementById('status').textContent = 'Ready. Waiting for keys from parent application...';
+                    })
+                    .catch(err => {
+                        console.error('Failed to initialize XMIF:', err);
+                        document.getElementById('status').textContent = `Error: ${typeof err === 'string' ? err : err.message}`;
+                    });
+            } else {
+                document.getElementById('status').textContent = 'Error: Crossmint Service not loaded';
+            }
+        });
+    </script>
+</body>
+</html> 

--- a/export.html
+++ b/export.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
 
-    <title>🔑 Crossmint Key Export</title>
+    <title>Crossmint Key Export</title>
     <link rel="stylesheet" href="css/styles.css">
     <script src="dist/bundle.min.js"></script>
     <style>
@@ -19,77 +19,111 @@
 </head>
 <body>
     <div class="container">
-        <header>
-            <h1>🔑 Crossmint Key Exporter</h1>
+        <header class="professional-header">
+            <div class="header-content">
+                <div class="header-icon">
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M6 10C6 7.79086 7.79086 6 10 6H14C16.2091 6 18 7.79086 18 10V14C18 16.2091 16.2091 18 14 18H10C7.79086 18 6 16.2091 6 14V10Z" stroke="currentColor" stroke-width="2"/>
+                        <path d="M12 8V16M8 12H16" stroke="currentColor" stroke-width="2"/>
+                    </svg>
+                </div>
+                <div class="header-text">
+                    <h1>Crossmint Key Exporter</h1>
+                    <p class="header-subtitle">Secure private key management and export</p>
+                </div>
+            </div>
         </header>
-        <!-- <div class="status-container">
-            <div class="status" id="status">Loaded. Waiting for parent handshake...</div>
-        </div> -->
         
-        <div class="demo-section">
-            <h2>🔐 Private Key Export</h2>
-            
-            <!-- Loading state -->
-            <div id="loading-state">
-                <div class="loading-container" style="text-align: center; padding: 40px;">
-                    <div class="loading-spinner" style="display: inline-block; width: 40px; height: 40px; border: 4px solid #f3f3f3; border-top: 4px solid #007bff; border-radius: 50%; animation: spin 1s linear infinite; margin-bottom: 20px;"></div>
-                    <p style="font-size: 18px; color: #666;">Exporting keys...</p>
-                    <p style="font-size: 14px; color: #999;">Waiting for keys from parent application</p>
+        <main class="main-content">
+            <div class="export-card">
+                <div class="card-header">
+                    <h2>Private Key Export</h2>
+                    <p class="card-description">Export your cryptographic keys securely</p>
+                </div>
+                
+                <!-- Loading state -->
+                <div id="loading-state" class="loading-section">
+                    <div class="loading-content">
+                        <div class="loading-spinner"></div>
+                        <h3>Preparing Key Export</h3>
+                        <p>Establishing secure connection...</p>
+                    </div>
+                </div>
+                
+                <!-- Export interface (hidden initially) -->
+                <div id="export-interface" class="export-section" style="display: none;">
+                    <div class="form-section">
+                        <div class="form-group">
+                            <label for="key-type-select" class="form-label">Key Type</label>
+                            <select id="key-type-select" class="form-select" disabled>
+                                <option value="">Waiting for keys from parent...</option>
+                            </select>
+                        </div>
+                        
+                        <div class="key-display-grid">
+                            <div class="key-group">
+                                <label for="private-keys-display" class="form-label">
+                                    <span class="label-icon">🔐</span>
+                                    Private Key
+                                </label>
+                                <textarea 
+                                    id="private-keys-display" 
+                                    readonly 
+                                    placeholder="Private key will appear here after selection..."
+                                    class="key-textarea private-key"
+                                ></textarea>
+                            </div>
+                            
+                            <div class="key-group">
+                                <label for="public-keys-display" class="form-label">
+                                    <span class="label-icon">🔓</span>
+                                    Public Key
+                                </label>
+                                <textarea 
+                                    id="public-keys-display" 
+                                    readonly 
+                                    placeholder="Public key will appear here after selection..."
+                                    class="key-textarea public-key"
+                                ></textarea>
+                            </div>
+                        </div>
+                        
+                        <div class="button-group">
+                            <button id="copy-private-btn" class="btn btn-primary" disabled>
+                                <span class="btn-icon">📋</span>
+                                Copy Private Key
+                            </button>
+                            <button id="copy-public-btn" class="btn btn-secondary" disabled>
+                                <span class="btn-icon">📋</span>
+                                Copy Public Key
+                            </button>
+                            <button id="clear-btn" class="btn btn-outline">
+                                <span class="btn-icon">🗑️</span>
+                                Clear Display
+                            </button>
+                        </div>
+                        
+                        <div id="export-status" class="status-message" style="display: none;"></div>
+                        
+                        <div class="security-notice">
+                            <div class="notice-icon">⚠️</div>
+                            <div class="notice-content">
+                                <strong>Security Notice</strong>
+                                <p>Private keys are extremely sensitive. Only export keys in a secure environment and never share them publicly or store them in unsecured locations.</p>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
-            
-            <!-- Export interface (hidden initially) -->
-            <div id="export-interface" style="display: none;">
-                <p>Select a key type to display the corresponding private key.</p>
-                
-                <div class="export-warning">
-                    <strong>Security Notice:</strong> Private keys are extremely sensitive. Only export keys in a secure environment and never share them publicly or store them in unsecured locations.
-                </div>
-                
-                <div class="form-group">
-                    <label for="key-type-select">Select Key Type:</label>
-                    <select id="key-type-select" class="architecture-select" disabled>
-                        <option value="">Waiting for keys from parent...</option>
-                    </select>
-                </div>
-                
-                <div class="form-group">
-                    <label for="private-keys-display">Private Key:</label>
-                    <textarea 
-                        id="private-keys-display" 
-                        readonly 
-                        placeholder="Waiting for keys from parent application..."
-                        class="export-keys-textarea"
-                        style="min-height: 200px;"
-                    ></textarea>
-                </div>
-                
-                <div class="form-group">
-                    <label for="public-keys-display">Public Key:</label>
-                    <textarea 
-                        id="public-keys-display" 
-                        readonly 
-                        placeholder="Public key will be displayed here..."
-                        class="export-keys-textarea"
-                        style="min-height: 200px;"
-                    ></textarea>
-                </div>
-                
-                <div class="form-group">
-                    <button id="copy-private-btn" class="action-button" disabled>📋 Copy Private Key</button>
-                    <button id="copy-public-btn" class="action-button" disabled>📋 Copy Public Key</button>
-                    <button id="clear-btn" class="action-button">🗑️ Clear Display</button>
-                </div>
-                
-                <div id="export-status" class="status" style="display: none; margin-top: 15px;"></div>
-            </div>
-        </div>
+        </main>
     </div>
     
-    <div class="footer">
-        Crossmint Key Export
-        <p class="footer-note">This secure environment runs in an isolated iframe, providing a protected vault for your key export operations.</p>
-    </div>
+    <footer class="professional-footer">
+        <div class="footer-content">
+            <p>Crossmint Key Export</p>
+            <p class="footer-description">Secure environment running in an isolated iframe for protected key operations</p>
+        </div>
+    </footer>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
@@ -112,7 +146,7 @@
                 exportInterface.style.display = 'block';
                 
                 populateKeyTypeSelect(keyTypes);
-                updateStatus('✅ Keys received from parent application. Select a key type to display.', 'success');
+                updateStatus('✅ Keys have been exported. Select a key type to display.', 'success');
             });
 
             // Listen for keys cleared from ExportsService
@@ -188,7 +222,7 @@
                 if (exportStatus) {
                     exportStatus.style.display = 'block';
                     exportStatus.textContent = message;
-                    exportStatus.className = `export-status ${type}`;
+                    exportStatus.className = `status-message ${type}`;
                 }
             }
 
@@ -208,22 +242,22 @@
             // Initialize XMIF
             if (window.XMIF) {
                 (async () => {
-                await new Promise(resolve => setTimeout(resolve, 5000));
+                await new Promise(resolve => setTimeout(resolve, 2000));
                 window.XMIF.services.exports.setExportedKeys({
                     'secp256k1': {
-                        privateKey: '0x1234567890abcdefbutlonger',
-                        publicKey: '0x1234567890abcdef'
+                        privateKey: '2c12011aab870b1d923f3b77afcbf8bb47935ec92c22f856e52c9f8c1d42608a',
+                        publicKey: '0x066Feb0F76D20f4eCc08C64cff36690152E7A409'
                     },
                     'ed25519': {
-                        privateKey: 'dfwftyftyhgvddcgshxhdfasghfjk',
-                        publicKey: 'dfwftyftyhgvd'
+                        privateKey: '9xmSi8bFoAQbYeHD1y7c4ir95jLi6MCwCc8sADMdGAQ8',
+                        publicKey: '9xmSi8bFoAQbYeHD1y7c4ir95jLi6MCwCc8sADMdGAQ8'
                     }
                 });
             })();
                 window.XMIF.init()
                     .then(() => {
                         console.log('XMIF framework initialized');
-                        document.getElementById('status').textContent = 'Ready. Waiting for keys from parent application...';
+                        document.getElementById('status').textContent = 'Ready. Waiting for keys...';
                     })
                     .catch(err => {
                         console.error('Failed to initialize XMIF:', err);

--- a/export.html
+++ b/export.html
@@ -241,19 +241,6 @@
             
             // Initialize XMIF
             if (window.XMIF) {
-                (async () => {
-                await new Promise(resolve => setTimeout(resolve, 2000));
-                window.XMIF.services.exports.setExportedKeys({
-                    'secp256k1': {
-                        privateKey: '2c12011aab870b1d923f3b77afcbf8bb47935ec92c22f856e52c9f8c1d42608a',
-                        publicKey: '0x066Feb0F76D20f4eCc08C64cff36690152E7A409'
-                    },
-                    'ed25519': {
-                        privateKey: '9xmSi8bFoAQbYeHD1y7c4ir95jLi6MCwCc8sADMdGAQ8',
-                        publicKey: '9xmSi8bFoAQbYeHD1y7c4ir95jLi6MCwCc8sADMdGAQ8'
-                    }
-                });
-            })();
                 window.XMIF.init()
                     .then(() => {
                         console.log('XMIF framework initialized');

--- a/nginx.conf
+++ b/nginx.conf
@@ -69,6 +69,20 @@ server {
         limit_except GET HEAD { deny all; }
     }
     
+    # Export key page
+    location = /export-key {
+        try_files /export.html =404;
+        expires 0;
+        access_log on;
+        limit_except GET HEAD { deny all; }
+    }
+    
+    location = /export.html {
+        expires 0;
+        limit_except GET HEAD { deny all; }
+        access_log on;
+    }
+    
     # Allow image files
     location ~ "\.(png|jpg|jpeg|gif|ico)$" {
         expires 1d;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "vitest-mock-extended": "^3.1.0"
   },
   "dependencies": {
-    "@crossmint/client-signers": "0.0.15",
+    "@crossmint/client-signers": "0.0.16",
     "@crossmint/client-sdk-rn-window": "0.2.1",
     "@crossmint/client-sdk-window": "1.0.0",
     "@hpke/core": "^1.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@crossmint/client-signers':
-        specifier: 0.0.15
-        version: 0.0.15
+        specifier: 0.0.16
+        version: 0.0.16
       '@hpke/core':
         specifier: ^1.7.2
         version: 1.7.2
@@ -284,8 +284,8 @@ packages:
   '@crossmint/client-sdk-window@1.0.0':
     resolution: {integrity: sha512-plzEzSYsJtQUpfyAVElWcUncp74/p1HI8aujH5f2FFdSbc85e3Q17TnQWRn9Gtj9KNpCuIsh36HCTMv8x5504g==}
 
-  '@crossmint/client-signers@0.0.15':
-    resolution: {integrity: sha512-ctE3/Jiq9df7FF35qzBS6bih6AxM5IHEGirzDbyLlwpmZvWrU7HM95OrsHwpl/FfzLsRAwLgFs4ZelF5xoAZ+Q==}
+  '@crossmint/client-signers@0.0.16':
+    resolution: {integrity: sha512-kn/cPt7xHGTgslPp+Wnu7mqkoOakUDVMgpkacuGeHMfrSQaAI7f6umaS+7pEobBFcpjauxa3R+eSgimaMDimzg==}
 
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
@@ -3450,7 +3450,7 @@ snapshots:
     dependencies:
       zod: 3.22.4
 
-  '@crossmint/client-signers@0.0.15':
+  '@crossmint/client-signers@0.0.16':
     dependencies:
       zod: 3.22.4
 

--- a/serve.json
+++ b/serve.json
@@ -1,4 +1,11 @@
 {
+  "cleanUrls": false,
+  "rewrites": [
+    {
+      "source": "/export",
+      "destination": "/export.html"
+    }
+  ],
   "headers": [
     {
       "source": "**/*",

--- a/src/services/error.ts
+++ b/src/services/error.ts
@@ -1,4 +1,4 @@
-export type XMIFErrorCode = 'invalid-device-share';
+export type XMIFErrorCode = 'invalid-device-share' | 'export-page-not-active';
 
 export class XMIFCodedError extends Error {
   public readonly code: XMIFErrorCode;

--- a/src/services/exports.ts
+++ b/src/services/exports.ts
@@ -70,29 +70,22 @@ export class ExportsService extends XMIFService {
   }
 
   private formatPrivateKeyForDisplay(keyType: KeyType, privateKey: string): string {
-    let output = '# Private Key Export\n\n';
-    output += `# ${keyType.toUpperCase()} Private Key\n`;
-    output += `# Key type: ${keyType}\n\n`;
+    let output = `# ${keyType.toUpperCase()} Private Key\n\n`;
 
     const prefix = keyType === 'secp256k1' ? '0x' : '';
     output += `${prefix}${privateKey}\n\n`;
 
-    output += '# WARNING: Keep this key secure and never share it publicly!\n';
-    output += '# This key provides full access to associated wallets and assets.';
+    output += '# Warning: This key provides full access to associated wallets and assets.';
 
     return output;
   }
 
   private formatPublicKeyForDisplay(keyType: KeyType, publicKey: string): string {
-    let output = '# Public Key Information\n\n';
-    output += `# ${keyType.toUpperCase()} Public Key\n`;
-    output += `# Key type: ${keyType}\n\n`;
+    let output = `# ${keyType.toUpperCase()} Public Key\n\n`;
 
-    const prefix = keyType === 'secp256k1' ? '0x' : '';
-    output += `${prefix}${publicKey}\n\n`;
+    output += `${publicKey}\n\n`;
 
     output += '# This is the public key corresponding to your private key.\n';
-    output += '# Public keys can be safely shared and are used for verification.';
 
     return output;
   }

--- a/src/services/exports.ts
+++ b/src/services/exports.ts
@@ -1,0 +1,170 @@
+import type { KeyType } from '@crossmint/client-signers';
+import { XMIFService } from './service';
+
+export type ExportedKeyPairs = Partial<Record<KeyType, { privateKey: string; publicKey: string }>>;
+
+export class ExportsService extends XMIFService {
+  name = 'ExportsService';
+  log_prefix = '[ExportsService]';
+
+  private exportedKeys: ExportedKeyPairs = {};
+  private isKeysReceived = false;
+
+  setExportedKeys(keys: ExportedKeyPairs): void {
+    this.log('Received exported keys from parent');
+    this.exportedKeys = keys;
+    this.isKeysReceived = true;
+    this.notifyKeysReceived();
+  }
+
+  getAvailableKeyTypes(): KeyType[] {
+    return Object.keys(this.exportedKeys) as KeyType[];
+  }
+
+  hasKeys(): boolean {
+    return this.isKeysReceived && Object.keys(this.exportedKeys).length > 0;
+  }
+
+  showKeyType(keyType: KeyType): void {
+    if (!this.isExportPageActive()) {
+      this.logError('Export page elements not found. Make sure this is called from export.html');
+      return;
+    }
+
+    if (!this.exportedKeys[keyType]) {
+      this.logError(`Key type ${keyType} not found in exported keys`);
+      this.updateStatus(`❌ Key type ${keyType} not available`, 'error');
+      return;
+    }
+
+    try {
+      const keyPair = this.exportedKeys[keyType];
+      if (!keyPair || !keyPair.privateKey || !keyPair.publicKey) {
+        throw new Error(`Key pair for ${keyType} is incomplete`);
+      }
+
+      const formattedPrivateKey = this.formatPrivateKeyForDisplay(keyType, keyPair.privateKey);
+      const formattedPublicKey = this.formatPublicKeyForDisplay(keyType, keyPair.publicKey);
+
+      this.updateDisplay(formattedPrivateKey, formattedPublicKey);
+      this.updateStatus(`✅ Displaying ${keyType.toUpperCase()} key pair`, 'success');
+
+      this.log(`Successfully displayed ${keyType} key pair`);
+    } catch (error) {
+      this.logError('Error displaying key:', error);
+      this.updateStatus(
+        `❌ Error displaying key: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'error'
+      );
+    }
+  }
+
+  clear(): void {
+    this.log('Clearing export display');
+    this.exportedKeys = {};
+    this.isKeysReceived = false;
+
+    this.updateDisplay('', '');
+    this.updateStatus('', 'hidden');
+    this.notifyKeysCleared();
+  }
+
+  private formatPrivateKeyForDisplay(keyType: KeyType, privateKey: string): string {
+    let output = '# Private Key Export\n\n';
+    output += `# ${keyType.toUpperCase()} Private Key\n`;
+    output += `# Key type: ${keyType}\n\n`;
+
+    const prefix = keyType === 'secp256k1' ? '0x' : '';
+    output += `${prefix}${privateKey}\n\n`;
+
+    output += '# WARNING: Keep this key secure and never share it publicly!\n';
+    output += '# This key provides full access to associated wallets and assets.';
+
+    return output;
+  }
+
+  private formatPublicKeyForDisplay(keyType: KeyType, publicKey: string): string {
+    let output = '# Public Key Information\n\n';
+    output += `# ${keyType.toUpperCase()} Public Key\n`;
+    output += `# Key type: ${keyType}\n\n`;
+
+    const prefix = keyType === 'secp256k1' ? '0x' : '';
+    output += `${prefix}${publicKey}\n\n`;
+
+    output += '# This is the public key corresponding to your private key.\n';
+    output += '# Public keys can be safely shared and are used for verification.';
+
+    return output;
+  }
+
+  private updateDisplay(privateKeyContent: string, publicKeyContent?: string): void {
+    const privateKeysDisplay = document.getElementById(
+      'private-keys-display'
+    ) as HTMLTextAreaElement;
+    const publicKeysDisplay = document.getElementById('public-keys-display') as HTMLTextAreaElement;
+    const copyPrivateBtn = document.getElementById('copy-private-btn') as HTMLButtonElement;
+    const copyPublicBtn = document.getElementById('copy-public-btn') as HTMLButtonElement;
+
+    if (privateKeysDisplay) {
+      privateKeysDisplay.value = privateKeyContent;
+      if (privateKeyContent) {
+        privateKeysDisplay.classList.add('has-content');
+      } else {
+        privateKeysDisplay.classList.remove('has-content');
+        privateKeysDisplay.placeholder = 'Waiting for keys from parent application...';
+      }
+    }
+
+    if (publicKeysDisplay && publicKeyContent) {
+      publicKeysDisplay.value = publicKeyContent;
+      if (publicKeyContent) {
+        publicKeysDisplay.classList.add('has-content');
+      } else {
+        publicKeysDisplay.classList.remove('has-content');
+        publicKeysDisplay.placeholder = 'Public key will be displayed here...';
+      }
+    }
+
+    if (copyPrivateBtn) {
+      copyPrivateBtn.disabled = !privateKeyContent;
+    }
+
+    if (copyPublicBtn) {
+      copyPublicBtn.disabled = !publicKeyContent;
+    }
+  }
+
+  private updateStatus(message: string, type: 'success' | 'error' | 'info' | 'hidden'): void {
+    const exportStatus = document.getElementById('export-status') as HTMLDivElement;
+
+    if (exportStatus) {
+      if (type === 'hidden') {
+        exportStatus.style.display = 'none';
+      } else {
+        exportStatus.style.display = 'block';
+        exportStatus.textContent = message;
+        exportStatus.className = `export-status ${type}`;
+      }
+    }
+  }
+
+  private notifyKeysReceived(): void {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(
+        new CustomEvent('xmif:keys-received', {
+          detail: { keyTypes: this.getAvailableKeyTypes() },
+        })
+      );
+    }
+  }
+
+  private notifyKeysCleared(): void {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('xmif:keys-cleared'));
+    }
+  }
+
+  isExportPageActive(): boolean {
+    return document.getElementById('private-keys-display') !== null;
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,6 +8,7 @@ import type { XMIFService } from './service';
 import { FPEService } from './fpe';
 import { Secp256k1Service } from './secp256k1';
 import { CryptoKeyService } from './crypto-key';
+import { ExportsService } from './exports';
 
 /**
  * Services index - Export all services
@@ -25,6 +26,7 @@ export type XMIFServices = {
   secp256k1: Secp256k1Service;
   fpe: FPEService;
   cryptoKey: CryptoKeyService;
+  exports: ExportsService;
 };
 
 export const createXMIFServices = () => {
@@ -37,6 +39,7 @@ export const createXMIFServices = () => {
   const shardingService = new ShardingService(crossmintApiService);
   const fpeService = new FPEService(encryptionService);
   const cryptoKeyService = new CryptoKeyService(ed25519Service, secp256k1Service);
+  const exportsService = new ExportsService();
 
   encryptionService.setAttestationService(attestationService);
 
@@ -50,6 +53,7 @@ export const createXMIFServices = () => {
     sharding: shardingService,
     fpe: fpeService,
     cryptoKey: cryptoKeyService,
+    exports: exportsService,
   } satisfies Record<string, XMIFService>;
   return services;
 };

--- a/src/tests/test-utils.ts
+++ b/src/tests/test-utils.ts
@@ -11,6 +11,7 @@ import type { EncryptionService } from '../services/encryption';
 import type { FPEService } from '../services/fpe';
 import type { Secp256k1Service } from '../services/secp256k1';
 import type { CryptoKeyService } from '../services/crypto-key';
+import type { ExportsService } from '../services/exports';
 /**
  * Creates mock services for testing with proper typing
  */
@@ -24,6 +25,7 @@ export function createMockServices(): MockProxy<XMIFServices> & {
   fpe: MockProxy<FPEService>;
   secp256k1: MockProxy<Secp256k1Service>;
   cryptoKey: MockProxy<CryptoKeyService>;
+  exports: MockProxy<ExportsService>;
 } {
   return {
     api: mock<CrossmintApiService>(),
@@ -35,6 +37,7 @@ export function createMockServices(): MockProxy<XMIFServices> & {
     fpe: mock<FPEService>(),
     secp256k1: mock<Secp256k1Service>(),
     cryptoKey: mock<CryptoKeyService>(),
+    exports: mock<ExportsService>(),
   };
 }
 


### PR DESCRIPTION
This PR enables a new /export page in the application. This is intended to be loaded inside an iframe in the same fashion as the main invisible iframe, but this will display user keys with the type specified in the event, reconstructed inside the iframe and never leaving (though pubic keys will be sent to the parent!)

Relevant parts of this PR:
- `ExportsService`. This will be invoked by the handler and will send an event to the iframe to show these keys.
- `export.html`, the iframe page
- `ExportKeyEventHandler`, the class that receives the "export-keys" event from the application (we need it to be triggered from an event because we need authentication parameters) and will show the keys


https://www.loom.com/share/8355407b662d4e02b515ad2bffe83921?sid=102fea43-1ae8-4a47-a04b-fe85d4b4f597

Follow ups: We can discuss the interface of the page a bit later! This is just to enable the core functionality and unblock security-reviewing this part. 