### PR TITLE
Verify Public Key From Attestation Report (Resolves WAL-4545)

### DIFF
--- a/src/services/attestation.test.ts
+++ b/src/services/attestation.test.ts
@@ -243,26 +243,5 @@ describe('AttestationService', () => {
         expect(result).toBe(false);
       }
     });
-
-    it('should handle large inputs and perform efficiently', async () => {
-      const publicKey = 'dGVzdA==';
-
-      // Large inputs should fail gracefully, not crash
-      const largeHexInput = 'a'.repeat(10000);
-      const largeBase64Input = 'dGVzdA=='.repeat(1000);
-
-      expect(await attestationService.reportAttestsPublicKey(largeHexInput, publicKey)).toBe(false);
-      expect(
-        await attestationService.reportAttestsPublicKey('a'.repeat(128), largeBase64Input)
-      ).toBe(false);
-
-      // Performance check on obvious mismatch
-      const start = performance.now();
-      const result = await attestationService.reportAttestsPublicKey('0'.repeat(128), publicKey);
-      const end = performance.now();
-
-      expect(result).toBe(false);
-      expect(end - start).toBeLessThan(100); // Should be fast
-    });
   });
 });

--- a/src/services/attestation.test.ts
+++ b/src/services/attestation.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the WASM imports before importing the AttestationService
+vi.mock('@phala/dcap-qvl-web', () => ({
+  default: vi.fn(), // mock the init function
+  js_get_collateral: vi.fn(),
+  js_verify: vi.fn(),
+}));
+
+vi.mock('@phala/dcap-qvl-web/dcap-qvl-web_bg.wasm', () => ({
+  default: {},
+}));
+
+import { AttestationService } from './attestation';
+import { mock } from 'vitest-mock-extended';
+import type { CrossmintApiService } from './api';
+
+describe('AttestationService', () => {
+  let attestationService: AttestationService;
+  let mockApiService: CrossmintApiService;
+
+  beforeEach(() => {
+    mockApiService = mock<CrossmintApiService>();
+    attestationService = new AttestationService(mockApiService);
+  });
+
+  // Helper function to calculate expected hash for a given input
+  async function calculateExpectedHash(input: string): Promise<string> {
+    const prefixBytes = new TextEncoder().encode('app-data:');
+    const inputBytes = new TextEncoder().encode(input);
+    const reconstructedReportData = new Uint8Array(prefixBytes.length + inputBytes.length);
+    reconstructedReportData.set(prefixBytes, 0);
+    reconstructedReportData.set(inputBytes, prefixBytes.length);
+
+    const hash = await crypto.subtle.digest('SHA-512', reconstructedReportData);
+    const hashArray = Array.from(new Uint8Array(hash));
+    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  describe('reportAttestsPublicKey', () => {
+    it('should return true when the public key hash matches the report data', async () => {
+      const publicKey = 'SGVsbG8gV29ybGQ='; // base64 encoded "Hello World"
+      const expectedReportData = await calculateExpectedHash('Hello World');
+
+      const result = await attestationService.reportAttestsPublicKey(expectedReportData, publicKey);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for mismatched hashes and wrong data', async () => {
+      const publicKey = 'dGVzdA=='; // base64 encoded "test"
+
+      const testCases = [
+        'abcdef1234567890'.repeat(8), // Wrong hash, correct length
+        '1234567890abcdef'.repeat(8), // Different wrong hash
+        '0'.repeat(128), // All zeros, correct length
+      ];
+
+      for (const wrongReportData of testCases) {
+        const result = await attestationService.reportAttestsPublicKey(wrongReportData, publicKey);
+        expect(result).toBe(false);
+      }
+    });
+
+    it('should handle empty inputs correctly', async () => {
+      const emptyPublicKey = ''; // empty base64 string
+      const expectedHash = await calculateExpectedHash('');
+
+      const result = await attestationService.reportAttestsPublicKey(expectedHash, emptyPublicKey);
+      expect(result).toBe(true);
+
+      // Empty report data should fail
+      const result2 = await attestationService.reportAttestsPublicKey('', 'dGVzdA==');
+      expect(result2).toBe(false);
+    });
+
+    it('should reject invalid lengths (SHA-512 must be exactly 64 bytes)', async () => {
+      const publicKey = 'dGVzdA==';
+
+      const invalidLengths = [
+        'abcd', // Too short (2 bytes)
+        'a'.repeat(126), // 63 bytes
+        'a'.repeat(130), // 65 bytes
+        'a'.repeat(64), // 32 bytes
+        'a'.repeat(256), // 128 bytes
+        '', // Empty
+      ];
+
+      for (const invalidLength of invalidLengths) {
+        const result = await attestationService.reportAttestsPublicKey(invalidLength, publicKey);
+        expect(result).toBe(false);
+      }
+    });
+
+    it('should accept exactly 128 hex characters and handle case insensitivity', async () => {
+      const publicKey = 'dGVzdA=='; // base64 encoded "test"
+      const expectedHash = await calculateExpectedHash('test');
+
+      // Verify it's exactly 128 characters (64 bytes)
+      expect(expectedHash).toHaveLength(128);
+
+      const upperCaseHash = expectedHash.toUpperCase();
+      const mixedCaseHash = expectedHash
+        .split('')
+        .map((char, i) => (i % 2 === 0 ? char.toUpperCase() : char.toLowerCase()))
+        .join('');
+
+      // All case variations should work
+      expect(await attestationService.reportAttestsPublicKey(expectedHash, publicKey)).toBe(true);
+      expect(await attestationService.reportAttestsPublicKey(upperCaseHash, publicKey)).toBe(true);
+      expect(await attestationService.reportAttestsPublicKey(mixedCaseHash, publicKey)).toBe(true);
+    });
+
+    it('should handle invalid characters gracefully without crashing', async () => {
+      const publicKey = 'dGVzdA==';
+
+      // Invalid hex characters
+      const invalidHexCases = [
+        `gggggggg${'a'.repeat(120)}`, // Contains 'g'
+        `xyz${'a'.repeat(125)}`, // Contains 'x', 'y', 'z'
+        `0x${'a'.repeat(126)}`, // Contains '0x' prefix
+        `你好世界${'a'.repeat(120)}`, // Unicode characters
+        `🚀🎉${'a'.repeat(124)}`, // Emojis
+      ];
+
+      for (const invalidHex of invalidHexCases) {
+        const result = await attestationService.reportAttestsPublicKey(invalidHex, publicKey);
+        expect(result).toBe(false);
+      }
+    });
+
+    it('should handle invalid base64 inputs gracefully', async () => {
+      const validHash = await calculateExpectedHash('test');
+
+      const invalidBase64Cases = [
+        '!!!invalid', // Completely invalid
+        'dGVzdA=!', // Contains '!'
+        'dGVzdA==@', // Contains '@'
+        'αβγδ', // Greek letters
+        'dG#Vzd', // Contains '#'
+        'dGVzdA===', // Too much padding
+      ];
+
+      for (const invalidBase64 of invalidBase64Cases) {
+        const result = await attestationService.reportAttestsPublicKey(validHash, invalidBase64);
+        expect(result).toBe(false);
+      }
+    });
+
+    it('should handle large inputs and perform efficiently', async () => {
+      const publicKey = 'dGVzdA==';
+
+      // Large inputs should fail gracefully, not crash
+      const largeHexInput = 'a'.repeat(10000);
+      const largeBase64Input = 'dGVzdA=='.repeat(1000);
+
+      expect(await attestationService.reportAttestsPublicKey(largeHexInput, publicKey)).toBe(false);
+      expect(
+        await attestationService.reportAttestsPublicKey('a'.repeat(128), largeBase64Input)
+      ).toBe(false);
+
+      // Performance check on obvious mismatch
+      const start = performance.now();
+      const result = await attestationService.reportAttestsPublicKey('0'.repeat(128), publicKey);
+      const end = performance.now();
+
+      expect(result).toBe(false);
+      expect(end - start).toBeLessThan(100); // Should be fast
+    });
+  });
+});

--- a/src/services/attestation.ts
+++ b/src/services/attestation.ts
@@ -54,7 +54,7 @@ export class AttestationService extends XMIFService {
     return this.publicKey;
   }
 
-  private async verifyAttestationAndParseKey(): Promise<string> {
+  async verifyAttestationAndParseKey(): Promise<string> {
     const attestation = await this.api.getAttestation();
     this.log('TEE attestation document fetched', JSON.stringify(attestation, null, 2));
 

--- a/src/services/attestation.ts
+++ b/src/services/attestation.ts
@@ -91,8 +91,8 @@ export class AttestationService extends XMIFService {
 
   async reportAttestsPublicKey(reportData: string, publicKey: string): Promise<boolean> {
     try {
-      const ReportDataHash = decodeBytes(reportData, 'hex');
-      if (ReportDataHash.length !== 64) {
+      const reportDataHash = decodeBytes(reportData, 'hex');
+      if (reportDataHash.length !== 64) {
         return false;
       }
 
@@ -104,7 +104,7 @@ export class AttestationService extends XMIFService {
 
       const hash = await crypto.subtle.digest(TEE_REPORT_DATA_HASH, reconstructedReportData);
       const hashView = new Uint8Array(hash);
-      return hashView.every((byte, i) => byte === ReportDataHash[i]);
+      return hashView.every((byte, i) => byte === reportDataHash[i]);
     } catch (error) {
       return false;
     }

--- a/src/services/attestation.ts
+++ b/src/services/attestation.ts
@@ -3,11 +3,38 @@ import { XMIFService } from './service';
 import init, { js_get_collateral, js_verify } from '@phala/dcap-qvl-web';
 import wasm from '@phala/dcap-qvl-web/dcap-qvl-web_bg.wasm';
 import { decodeBytes } from './utils';
+import { z } from 'zod';
 import { isDevelopment } from './environment';
 
 const PCCS_URL = 'https://pccs.phala.network/tdx/certification/v4';
 const ATTESTATION_VERIFIED_STATUS = 'UpToDate';
+const TEE_REPORT_DATA_PREFIX = 'app-data:';
+const TEE_REPORT_DATA_HASH = 'SHA-512' as const;
 
+// Minimal TEE report validation schema
+const AttestationReportSchema = z.object({
+  status: z.string(),
+  advisory_ids: z.array(z.string()),
+  report: z.object({
+    TD10: z.object({
+      tee_tcb_svn: z.string(),
+      mr_seam: z.string(),
+      mr_signer_seam: z.string(),
+      seam_attributes: z.string(),
+      td_attributes: z.string(),
+      xfam: z.string(),
+      mr_td: z.string(),
+      mr_config_id: z.string(),
+      mr_owner: z.string(),
+      mr_owner_config: z.string(),
+      rt_mr0: z.string(),
+      rt_mr1: z.string(),
+      rt_mr2: z.string(),
+      rt_mr3: z.string(),
+      report_data: z.string(),
+    }),
+  }),
+});
 export class AttestationService extends XMIFService {
   name = 'Attestation Service';
   log_prefix = '[AttestationService]';
@@ -42,7 +69,7 @@ export class AttestationService extends XMIFService {
     return this.publicKey;
   }
 
-  async verifyAttestationAndParseKey(): Promise<string> {
+  private async verifyAttestationAndParseKey(): Promise<string> {
     const attestation = await this.api.getAttestation();
     this.log('TEE attestation document fetched', JSON.stringify(attestation, null, 2));
 
@@ -52,18 +79,42 @@ export class AttestationService extends XMIFService {
     const collateral = await js_get_collateral(PCCS_URL, decodedQuote);
 
     const currentTime = BigInt(Math.floor(Date.now() / 1000));
-    const { status } = await js_verify(decodedQuote, collateral, currentTime);
+    const report = await js_verify(decodedQuote, collateral, currentTime);
+    const validatedReport = AttestationReportSchema.parse(report);
 
-    if (status !== ATTESTATION_VERIFIED_STATUS) {
-      throw new Error('TEE Attestation is invalid');
+    if (validatedReport.status !== ATTESTATION_VERIFIED_STATUS) {
+      throw new Error('TEE attestation is invalid');
+    }
+
+    const publicKeyIsAttested = await this.reportAttestsPublicKey(
+      validatedReport.report.TD10.report_data,
+      attestation.publicKey
+    );
+
+    if (!publicKeyIsAttested) {
+      throw new Error('TEE reported public key does not match attestation report');
     }
 
     this.log('TEE attestation document validated! Continuing...');
-    return attestation.publicKey; // TODO parse key from attestation "report_data".
+    return attestation.publicKey;
   }
 
-  async getPublicKeyDevMode(): Promise<string> {
+  private async getPublicKeyDevMode(): Promise<string> {
     const response = await this.api.getPublicKey();
     return response.publicKey;
+  }
+
+  private async reportAttestsPublicKey(reportData: string, publicKey: string): Promise<boolean> {
+    const ReportDataHash = decodeBytes(reportData, 'hex');
+
+    const prefixBytes = new TextEncoder().encode(TEE_REPORT_DATA_PREFIX);
+    const publicKeyBytes = decodeBytes(publicKey, 'base64');
+    const reconstructedReportData = new Uint8Array(prefixBytes.length + publicKeyBytes.length);
+    reconstructedReportData.set(prefixBytes, 0);
+    reconstructedReportData.set(publicKeyBytes, prefixBytes.length);
+
+    const hash = await crypto.subtle.digest(TEE_REPORT_DATA_HASH, reconstructedReportData);
+    const hashView = new Uint8Array(hash);
+    return hashView.every((byte, i) => byte === ReportDataHash[i]);
   }
 }

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -14,6 +14,8 @@ export function decodeBytes(bytes: string, encoding: 'base64' | 'base58' | 'hex'
       return bs58.decode(bytes);
     case 'hex':
       return new Uint8Array(bytes.match(/.{1,2}/g)?.map(byte => Number.parseInt(byte, 16)) || []);
+    case 'base64':
+      return Uint8Array.from(atob(bytes), c => c.charCodeAt(0));
     default:
       throw new Error(`Unsupported encoding: ${encoding}`);
   }


### PR DESCRIPTION
## Description

Attestations from dstack include a `report_data` field, which is the hash (default algorithm = SHA-512) of data provided to `new TappdClient().tdxQuote(reportData)`.

This PR uses the `report_data` field from the attestation to verify that the public key included in the response from the Crossmint relay to `/v1/attestation` is signed by the TEE, authenticating the key.

## Testing

Running the crossmint relay locally, I routed `v1/attestation` to hit `https://tee.crossmint.com/v1/attestation`, and tested the public key verification e2e.

This PR also adds comprehensive unit testing for the entire attestations service, including the new functionality.