### PR TITLE
Bullet Proofing (Resolves WAL-4593 and WAL-4592)

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -83,16 +83,14 @@ export class CrossmintApiService extends XMIFService {
     deviceId: z.string(),
   });
   static completeOnboardingOutputSchema = z.object({
-    shares: z.object({
-      device: z.string(),
-      auth: z.string(),
-    }),
+    deviceKeyShare: z.string(),
+    signerId: z.string(),
   });
 
   static getAuthShardInputSchema = z.undefined();
   static getAuthShardOutputSchema = z.object({
-    deviceId: z.string(),
-    keyShare: z.string(),
+    signerId: z.string(),
+    authKeyShare: z.string(),
     deviceKeyShareHash: z.string(),
   });
 

--- a/src/services/auth-share-cache.test.ts
+++ b/src/services/auth-share-cache.test.ts
@@ -2,7 +2,7 @@
  * SECURITY CRITICAL: AuthShareCache Test Suite
  *
  * This service manages cached authentication shares for Shamir Secret Sharing.
- * Security properties tested:
+ * Properties tested:
  * 1. Credential isolation - different auth contexts get separate caches
  * 2. Cache TTL enforcement - prevents stale auth share access
  * 3. Error handling - 404s return null, other errors propagate
@@ -42,9 +42,7 @@ describe('AuthShareCache - Security Critical Tests', () => {
       });
     });
 
-    it('SECURITY: Should cache auth share to reduce API calls and improve performance', async () => {
-      // SECURITY PROPERTY: Caching reduces attack surface by minimizing API requests
-
+    it('Should cache auth share to reduce API calls and improve performance', async () => {
       // First call should hit API
       const result1 = await service.getAuthShare(TEST_DEVICE_ID, BASE_AUTH_DATA);
       expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(1);
@@ -60,8 +58,7 @@ describe('AuthShareCache - Security Critical Tests', () => {
       expect(result2).toEqual(result1);
     });
 
-    it('SECURITY: Should enforce cache TTL to prevent stale auth share access', async () => {
-      // SECURITY PROPERTY: TTL prevents using outdated authentication shares
+    it('Should enforce cache TTL to prevent stale auth share access', async () => {
       const originalDateNow = Date.now;
       let currentTime = 1000000;
       vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
@@ -84,8 +81,7 @@ describe('AuthShareCache - Security Critical Tests', () => {
   });
 
   describe('Error Handling - Security Boundaries', () => {
-    it('SECURITY: Should safely handle missing auth shares (404) without exposing errors', async () => {
-      // SECURITY PROPERTY: Missing shares return null (fail-safe) rather than throwing
+    it('Should safely handle missing auth shares (404) without exposing errors', async () => {
       const notFoundError = new CrossmintHttpError(
         404,
         'Not Found',
@@ -99,8 +95,7 @@ describe('AuthShareCache - Security Critical Tests', () => {
       expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(1);
     });
 
-    it('SECURITY: Should propagate non-404 errors for proper error handling', async () => {
-      // SECURITY PROPERTY: Real errors (server issues, auth failures) should bubble up
+    it('Should propagate non-404 errors for proper error handling', async () => {
       const serverError = new CrossmintHttpError(
         500,
         'Internal Server Error',

--- a/src/services/auth-share-cache.test.ts
+++ b/src/services/auth-share-cache.test.ts
@@ -1,0 +1,301 @@
+/**
+ * SECURITY CRITICAL: AuthShareCache Test Suite
+ *
+ * This service manages cached authentication shares for Shamir Secret Sharing.
+ * Security properties tested:
+ * 1. Credential isolation - different auth contexts get separate caches
+ * 2. Cache TTL enforcement - prevents stale auth share access
+ * 3. Error handling - 404s return null, other errors propagate
+ * 4. JWT refresh isolation - new JWTs cannot access old cached shares
+ * 5. API key isolation - different apps cannot access each other's shares
+ * 6. Cache clearing for security cleanup scenarios
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockServices } from '../tests/test-utils';
+import { CrossmintHttpError } from './request';
+import { AuthShareCache } from './auth-share-cache';
+
+// Test constants
+const TEST_DEVICE_ID = 'test-device-id';
+const BASE_AUTH_DATA = { jwt: 'base-jwt', apiKey: 'base-api-key' };
+
+describe('AuthShareCache - Security Critical Tests', () => {
+  const mockServices = createMockServices();
+  let service: AuthShareCache;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    service = new AuthShareCache(mockServices.api);
+
+    // Suppress console output in tests
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  describe('Basic Cache Operations', () => {
+    beforeEach(() => {
+      mockServices.api.getAuthShard.mockResolvedValue({
+        authKeyShare: 'test-auth-share',
+        deviceKeyShareHash: 'h(xyz)',
+        signerId: 'test-signer',
+      });
+    });
+
+    it('SECURITY: Should cache auth share to reduce API calls and improve performance', async () => {
+      // SECURITY PROPERTY: Caching reduces attack surface by minimizing API requests
+
+      // First call should hit API
+      const result1 = await service.getAuthShare(TEST_DEVICE_ID, BASE_AUTH_DATA);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(1);
+      expect(result1).toEqual({
+        authKeyShare: 'test-auth-share',
+        deviceKeyShareHash: 'h(xyz)',
+        signerId: 'test-signer',
+      });
+
+      // Second call should use cache (no additional API call)
+      const result2 = await service.getAuthShare(TEST_DEVICE_ID, BASE_AUTH_DATA);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(1);
+      expect(result2).toEqual(result1);
+    });
+
+    it('SECURITY: Should enforce cache TTL to prevent stale auth share access', async () => {
+      // SECURITY PROPERTY: TTL prevents using outdated authentication shares
+      const originalDateNow = Date.now;
+      let currentTime = 1000000;
+      vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
+
+      try {
+        // First call - should cache
+        await service.getAuthShare(TEST_DEVICE_ID, BASE_AUTH_DATA);
+        expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(1);
+
+        // Advance time beyond cache TTL (5 minutes = 300,000ms)
+        currentTime += 300001;
+
+        // Second call should fetch fresh data due to TTL expiration
+        await service.getAuthShare(TEST_DEVICE_ID, BASE_AUTH_DATA);
+        expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(2);
+      } finally {
+        Date.now = originalDateNow;
+      }
+    });
+  });
+
+  describe('Error Handling - Security Boundaries', () => {
+    it('SECURITY: Should safely handle missing auth shares (404) without exposing errors', async () => {
+      // SECURITY PROPERTY: Missing shares return null (fail-safe) rather than throwing
+      const notFoundError = new CrossmintHttpError(
+        404,
+        'Not Found',
+        'https://api.test.com/auth-shard'
+      );
+      mockServices.api.getAuthShard.mockRejectedValueOnce(notFoundError);
+
+      const result = await service.getAuthShare(TEST_DEVICE_ID, BASE_AUTH_DATA);
+
+      expect(result).toBeNull();
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(1);
+    });
+
+    it('SECURITY: Should propagate non-404 errors for proper error handling', async () => {
+      // SECURITY PROPERTY: Real errors (server issues, auth failures) should bubble up
+      const serverError = new CrossmintHttpError(
+        500,
+        'Internal Server Error',
+        'https://api.test.com/auth-shard'
+      );
+      mockServices.api.getAuthShard.mockRejectedValueOnce(serverError);
+
+      await expect(service.getAuthShare(TEST_DEVICE_ID, BASE_AUTH_DATA)).rejects.toThrow(
+        CrossmintHttpError
+      );
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Credential Isolation - Cross-Access Prevention', () => {
+    // SECURITY CRITICAL: These tests verify that different authentication contexts cannot access each other's cached data
+
+    const CREDENTIAL_SCENARIOS = {
+      originalUser: {
+        authData: { jwt: 'user1-jwt', apiKey: 'app-api-key' },
+        signerId: 'signer-user1',
+        authShare: 'user1-auth-share',
+      },
+      differentUser: {
+        authData: { jwt: 'user2-jwt', apiKey: 'app-api-key' }, // Same app, different user
+        signerId: 'signer-user2',
+        authShare: 'user2-auth-share',
+      },
+      differentApp: {
+        authData: { jwt: 'user1-jwt', apiKey: 'different-app-api-key' }, // Same user, different app
+        signerId: 'signer-different-app',
+        authShare: 'different-app-auth-share',
+      },
+      completelyDifferent: {
+        authData: { jwt: 'other-jwt', apiKey: 'other-api-key' }, // Different user and app
+        signerId: 'signer-other',
+        authShare: 'other-auth-share',
+      },
+    };
+
+    beforeEach(() => {
+      mockServices.api.getAuthShard.mockImplementation(async (deviceId, _, authData) => {
+        const scenario = Object.values(CREDENTIAL_SCENARIOS).find(
+          s => s.authData.jwt === authData.jwt && s.authData.apiKey === authData.apiKey
+        );
+
+        if (scenario) {
+          return {
+            authKeyShare: scenario.authShare,
+            deviceKeyShareHash: 'h(xyz)',
+            signerId: scenario.signerId,
+          };
+        }
+
+        throw new Error(`Unexpected auth data: ${JSON.stringify(authData)}`);
+      });
+    });
+
+    it('SECURITY: Should isolate caches when JWT changes (different users)', async () => {
+      // SECURITY PROPERTY: Different JWTs = different users = separate caches
+
+      // Original user caches their auth share
+      await service.getAuthShare(TEST_DEVICE_ID, CREDENTIAL_SCENARIOS.originalUser.authData);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(1);
+
+      // Different user should trigger new API call (cache miss due to different JWT)
+      await service.getAuthShare(TEST_DEVICE_ID, CREDENTIAL_SCENARIOS.differentUser.authData);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(2);
+
+      // Original user's subsequent call should still use cache
+      await service.getAuthShare(TEST_DEVICE_ID, CREDENTIAL_SCENARIOS.originalUser.authData);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(2);
+    });
+
+    it('SECURITY: Should isolate caches when API key changes (different apps)', async () => {
+      // SECURITY PROPERTY: Different API keys = different apps = separate caches
+
+      // Original app caches auth share
+      await service.getAuthShare(TEST_DEVICE_ID, CREDENTIAL_SCENARIOS.originalUser.authData);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(1);
+
+      // Different app should trigger new API call (cache miss due to different API key)
+      await service.getAuthShare(TEST_DEVICE_ID, CREDENTIAL_SCENARIOS.differentApp.authData);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(2);
+
+      // Original app's subsequent call should still use cache
+      await service.getAuthShare(TEST_DEVICE_ID, CREDENTIAL_SCENARIOS.originalUser.authData);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(2);
+    });
+
+    it('SECURITY: Should isolate caches when both JWT and API key change', async () => {
+      // SECURITY PROPERTY: Complete credential change = complete isolation
+
+      // Original credentials cache auth share
+      await service.getAuthShare(TEST_DEVICE_ID, CREDENTIAL_SCENARIOS.originalUser.authData);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(1);
+
+      // Completely different credentials should trigger new API call
+      await service.getAuthShare(TEST_DEVICE_ID, CREDENTIAL_SCENARIOS.completelyDifferent.authData);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(2);
+
+      // Original credentials should still use cache
+      await service.getAuthShare(TEST_DEVICE_ID, CREDENTIAL_SCENARIOS.originalUser.authData);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(2);
+    });
+
+    it('SECURITY: Should maintain completely separate caches for all credential combinations', async () => {
+      // SECURITY PROPERTY: Each unique credential combination gets its own isolated cache
+
+      // Call with all different credential combinations - each should hit API
+      const scenarios = Object.values(CREDENTIAL_SCENARIOS);
+      for (const scenario of scenarios) {
+        await service.getAuthShare(TEST_DEVICE_ID, scenario.authData);
+      }
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(4);
+
+      // Repeat all calls - each should use its respective cache (no additional API calls)
+      for (const scenario of scenarios) {
+        await service.getAuthShare(TEST_DEVICE_ID, scenario.authData);
+      }
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(4);
+    });
+
+    it('SECURITY: Should prevent access to cached shares after JWT refresh', async () => {
+      // SECURITY PROPERTY: JWT refresh creates new authentication context
+      const expiredJwtAuthData = { jwt: 'expired-jwt-v1', apiKey: 'app-api-key' };
+      const refreshedJwtAuthData = { jwt: 'refreshed-jwt-v2', apiKey: 'app-api-key' };
+
+      mockServices.api.getAuthShard.mockImplementation(async (deviceId, _, authData) => {
+        if (authData.jwt === 'expired-jwt-v1') {
+          return {
+            authKeyShare: 'expired-auth-share',
+            deviceKeyShareHash: 'h(xyz)',
+            signerId: 'signer-expired',
+          };
+        }
+        if (authData.jwt === 'refreshed-jwt-v2') {
+          return {
+            authKeyShare: 'refreshed-auth-share',
+            deviceKeyShareHash: 'h(xyz)',
+            signerId: 'signer-refreshed',
+          };
+        }
+        throw new Error('Unexpected JWT');
+      });
+
+      // Cache with expired JWT
+      await service.getAuthShare(TEST_DEVICE_ID, expiredJwtAuthData);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(1);
+
+      // After JWT refresh, new token should not access old cache
+      await service.getAuthShare(TEST_DEVICE_ID, refreshedJwtAuthData);
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(2);
+
+      // Verify correct credential isolation
+      expect(mockServices.api.getAuthShard).toHaveBeenNthCalledWith(
+        1,
+        TEST_DEVICE_ID,
+        undefined,
+        expiredJwtAuthData
+      );
+      expect(mockServices.api.getAuthShard).toHaveBeenNthCalledWith(
+        2,
+        TEST_DEVICE_ID,
+        undefined,
+        refreshedJwtAuthData
+      );
+    });
+  });
+
+  describe('Cache Management - Security Cleanup', () => {
+    it('SECURITY: Should clear all cached entries for security cleanup scenarios', async () => {
+      // SECURITY PROPERTY: Cache clearing enables secure cleanup on tampering detection
+      mockServices.api.getAuthShard.mockImplementation(async (deviceId, _, authData) => {
+        if (authData.jwt === 'test-jwt-1') {
+          return { authKeyShare: 'share-1', deviceKeyShareHash: 'h(xyz)', signerId: 'signer-1' };
+        }
+        if (authData.jwt === 'test-jwt-2') {
+          return { authKeyShare: 'share-2', deviceKeyShareHash: 'h(xyz)', signerId: 'signer-2' };
+        }
+        throw new Error(`Unexpected auth data: ${JSON.stringify(authData)}`);
+      });
+
+      // Populate cache with multiple entries
+      await service.getAuthShare(TEST_DEVICE_ID, { jwt: 'test-jwt-1', apiKey: 'api-key-1' });
+      await service.getAuthShare(TEST_DEVICE_ID, { jwt: 'test-jwt-2', apiKey: 'api-key-2' });
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(2);
+
+      // Clear cache (security cleanup)
+      service.clearCache();
+
+      // Subsequent calls should hit API again (cache was cleared)
+      await service.getAuthShare(TEST_DEVICE_ID, { jwt: 'test-jwt-1', apiKey: 'api-key-1' });
+      await service.getAuthShare(TEST_DEVICE_ID, { jwt: 'test-jwt-2', apiKey: 'api-key-2' });
+      expect(mockServices.api.getAuthShard).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/src/services/auth-share-cache.ts
+++ b/src/services/auth-share-cache.ts
@@ -1,0 +1,76 @@
+import { XMIFService } from './service';
+import type { CrossmintApiService } from './api';
+import { CrossmintHttpError } from './request';
+
+interface AuthShardCacheEntry {
+  authKeyShare: string;
+  deviceKeyShareHash: string;
+  signerId: string;
+  timestamp: number;
+}
+
+interface AuthShardData {
+  authKeyShare: string;
+  deviceKeyShareHash: string;
+  signerId: string;
+}
+
+export class AuthShareCache extends XMIFService {
+  name = 'Auth Share Cache';
+  log_prefix = '[AuthShareCache]';
+
+  private authShardCache = new Map<string, AuthShardCacheEntry>();
+
+  constructor(
+    private readonly api: CrossmintApiService,
+    private readonly CACHE_TTL_MS = 5 * 60 * 1000
+  ) {
+    super();
+  }
+
+  async init() {}
+
+  public async getAuthShare(
+    deviceId: string,
+    authData: { jwt: string; apiKey: string }
+  ): Promise<AuthShardData | null> {
+    const cacheKey = `${deviceId}-${authData.apiKey}-${authData.jwt}`;
+
+    const cached = this.authShardCache.get(cacheKey);
+    if (cached && Date.now() - cached.timestamp < this.CACHE_TTL_MS) {
+      this.log('Using cached auth share');
+      return {
+        authKeyShare: cached.authKeyShare,
+        deviceKeyShareHash: cached.deviceKeyShareHash,
+        signerId: cached.signerId,
+      };
+    }
+
+    try {
+      this.log('Fetching auth share from API');
+      const result = await this.api.getAuthShard(deviceId, undefined, authData);
+      this.authShardCache.set(cacheKey, {
+        authKeyShare: result.authKeyShare,
+        deviceKeyShareHash: result.deviceKeyShareHash,
+        signerId: result.signerId,
+        timestamp: Date.now(),
+      });
+
+      return {
+        authKeyShare: result.authKeyShare,
+        deviceKeyShareHash: result.deviceKeyShareHash,
+        signerId: result.signerId,
+      };
+    } catch (e) {
+      if (e instanceof CrossmintHttpError && e.status === 404) {
+        return null;
+      }
+
+      throw e;
+    }
+  }
+
+  public clearCache(): void {
+    this.authShardCache.clear();
+  }
+}

--- a/src/services/auth-share-cache.ts
+++ b/src/services/auth-share-cache.ts
@@ -52,7 +52,31 @@ export class AuthShareCache extends XMIFService {
 
   async init() {}
 
-  public async getAuthShare(
+  /**
+   * Retrieves an authentication share with intelligent caching for performance optimization.
+   *
+   * This method implements a cache-first strategy to minimize API calls while maintaining security:
+   * 1. **Cache Check**: First checks if a valid cached entry exists for the credential combination
+   * 2. **TTL Validation**: Ensures cached entries haven't exceeded the 5-minute time-to-live
+   * 3. **API Fallback**: Fetches from Crossmint API if cache miss or expired entry
+   * 4. **Automatic Caching**: Stores successful API responses for future requests
+   *
+   * Cache isolation is maintained through a composite key that includes device ID, API key,
+   * and JWT, ensuring that different users, applications, or authentication contexts cannot
+   * access each other's cached authentication shares.
+   *
+   * The method gracefully handles missing authentication shares by returning null (e.g., when
+   * a user hasn't been properly enrolled), while propagating other API errors for proper
+   * error handling by the calling code.
+   *
+   * @param deviceId - Unique device identifier for cache isolation
+   * @param authData - Authentication credentials for API access
+   * @param authData.jwt - JSON Web Token for user authentication
+   * @param authData.apiKey - API key for application authentication
+   * @returns Promise resolving to auth share data if available, null if not found (404)
+   * @throws {Error} For API errors other than 404 (network issues, invalid credentials, etc.)
+   */
+  public async get(
     deviceId: string,
     authData: { jwt: string; apiKey: string }
   ): Promise<AuthShardData | null> {

--- a/src/services/auth-share-cache.ts
+++ b/src/services/auth-share-cache.ts
@@ -124,7 +124,7 @@ export class AuthShareCache extends XMIFService {
     return `${deviceId}-${authData.apiKey}-${authData.jwt}`;
   }
 
-  private isCacheEntryValid(cached: AuthShardCacheEntry): cached is AuthShardCacheEntry {
+  private isCacheEntryValid(cached: AuthShardCacheEntry): boolean {
     return Date.now() - cached.timestamp < this.CACHE_TTL_MS;
   }
 }

--- a/src/services/auth-share-cache.ts
+++ b/src/services/auth-share-cache.ts
@@ -83,7 +83,7 @@ export class AuthShareCache extends XMIFService {
     const cacheKey = this.buildCacheKey(deviceId, authData);
 
     const cached = this.authShardCache.get(cacheKey);
-    if (this.isCacheEntryValid(cached)) {
+    if (cached != null && this.isCacheEntryValid(cached)) {
       this.log('Using cached auth share');
       return {
         authKeyShare: cached.authKeyShare,
@@ -124,9 +124,7 @@ export class AuthShareCache extends XMIFService {
     return `${deviceId}-${authData.apiKey}-${authData.jwt}`;
   }
 
-  private isCacheEntryValid(
-    cached: AuthShardCacheEntry | undefined
-  ): cached is AuthShardCacheEntry {
-    return cached !== undefined && Date.now() - cached.timestamp < this.CACHE_TTL_MS;
+  private isCacheEntryValid(cached: AuthShardCacheEntry): cached is AuthShardCacheEntry {
+    return Date.now() - cached.timestamp < this.CACHE_TTL_MS;
   }
 }

--- a/src/services/auth-share-cache.ts
+++ b/src/services/auth-share-cache.ts
@@ -15,6 +15,28 @@ interface AuthShardData {
   signerId: string;
 }
 
+/**
+ * In-memory cache for authentication shares used in Shamir Secret Sharing.
+ *
+ * **IMPORTANT: This is an in-memory cache that lives within the iframe context.**
+ *
+ * The cache is automatically cleared when:
+ * - **Page refresh/reload** - Browser discards the iframe's JavaScript context
+ * - **Tab close** - Browser terminates the iframe along with its memory
+ * - **Browser navigation away** - Parent page navigation destroys the iframe
+ * - **Iframe removal** - Parent page removes the iframe from DOM
+ * - **Browser crash/restart** - All memory is lost
+ * - **Manual cache clear** - Explicit call to `clearCache()` method
+ * - **Security cleanup** - Called during device share tampering detection
+ *
+ * The cache uses a 5-minute TTL (time-to-live) to automatically expire entries
+ * and ensure auth shares don't remain in memory indefinitely. Each cache entry
+ * is isolated by device ID, API key, and JWT to prevent cross-contamination
+ * between different authentication contexts.
+ *
+ * Since this cache exists in iframe memory, it provides no persistence across
+ * browser sessions and is automatically cleaned up when the iframe context ends.
+ */
 export class AuthShareCache extends XMIFService {
   name = 'Auth Share Cache';
   log_prefix = '[AuthShareCache]';
@@ -34,10 +56,10 @@ export class AuthShareCache extends XMIFService {
     deviceId: string,
     authData: { jwt: string; apiKey: string }
   ): Promise<AuthShardData | null> {
-    const cacheKey = `${deviceId}-${authData.apiKey}-${authData.jwt}`;
+    const cacheKey = this.buildCacheKey(deviceId, authData);
 
     const cached = this.authShardCache.get(cacheKey);
-    if (cached && Date.now() - cached.timestamp < this.CACHE_TTL_MS) {
+    if (this.isCacheEntryValid(cached)) {
       this.log('Using cached auth share');
       return {
         authKeyShare: cached.authKeyShare,
@@ -72,5 +94,15 @@ export class AuthShareCache extends XMIFService {
 
   public clearCache(): void {
     this.authShardCache.clear();
+  }
+
+  private buildCacheKey(deviceId: string, authData: { jwt: string; apiKey: string }): string {
+    return `${deviceId}-${authData.apiKey}-${authData.jwt}`;
+  }
+
+  private isCacheEntryValid(
+    cached: AuthShardCacheEntry | undefined
+  ): cached is AuthShardCacheEntry {
+    return cached !== undefined && Date.now() - cached.timestamp < this.CACHE_TTL_MS;
   }
 }

--- a/src/services/device.test.ts
+++ b/src/services/device.test.ts
@@ -1,17 +1,6 @@
-/**
- * SECURITY CRITICAL: DeviceService Test Suite
- *
- * This service manages device ID generation and storage.
- * Security properties tested:
- * 1. Device ID uniqueness and unpredictability
- * 2. Device identity persistence across sessions
- * 3. Secure cleanup when needed
- */
-
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DeviceService } from './device';
 
-// Test constants
 const TEST_DEVICE_ID = '123e4567-e89b-12d3-a456-426614174000';
 const DEVICE_ID_KEY = 'device-id';
 
@@ -53,8 +42,7 @@ describe('DeviceService - Security Critical Tests', () => {
   });
 
   describe('Device ID Generation - Isolation Foundation', () => {
-    it('SECURITY: Should generate cryptographically random device ID when none exists', () => {
-      // SECURITY PROPERTY: Each device gets a unique, unpredictable identifier
+    it('Should generate cryptographically random device ID when none exists', () => {
       mockLocalStorage.getItem.mockReturnValueOnce(null);
 
       const result = service.getId();
@@ -64,8 +52,7 @@ describe('DeviceService - Security Critical Tests', () => {
       expect(result).toBe(TEST_DEVICE_ID);
     });
 
-    it('SECURITY: Should reuse existing device ID to maintain device identity', () => {
-      // SECURITY PROPERTY: Device identity persists across sessions
+    it('Should reuse existing device ID to maintain device identity', () => {
       mockLocalStorage.getItem.mockReturnValueOnce(TEST_DEVICE_ID);
 
       const result = service.getId();
@@ -76,7 +63,6 @@ describe('DeviceService - Security Critical Tests', () => {
     });
 
     it('SECURITY: Should generate new device ID each time when none exists in storage', () => {
-      // SECURITY PROPERTY: Multiple calls without existing storage create unique IDs
       const firstDeviceId = '123e4567-e89b-12d3-a456-426614174001';
       const secondDeviceId = '123e4567-e89b-12d3-a456-426614174002';
 
@@ -95,14 +81,13 @@ describe('DeviceService - Security Critical Tests', () => {
   });
 
   describe('Device ID Cleanup - Security Operations', () => {
-    it('SECURITY: Should clear device ID from storage for security cleanup', () => {
-      // SECURITY PROPERTY: Device ID can be securely removed when needed
+    it('Should clear device ID from storage for security cleanup', () => {
       service.clearId();
 
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(DEVICE_ID_KEY);
     });
 
-    it('SECURITY: Should handle multiple clear operations safely', () => {
+    it('Should handle multiple clear operations safely', () => {
       // SECURITY PROPERTY: Multiple clears don't cause errors
       service.clearId();
       service.clearId();
@@ -114,7 +99,6 @@ describe('DeviceService - Security Critical Tests', () => {
 
   describe('Device ID Persistence', () => {
     it('Should maintain device identity across service instances', () => {
-      // SECURITY PROPERTY: Device identity is consistent across service recreations
       mockLocalStorage.getItem.mockReturnValue(TEST_DEVICE_ID);
 
       const service1 = new DeviceService();

--- a/src/services/device.test.ts
+++ b/src/services/device.test.ts
@@ -1,0 +1,131 @@
+/**
+ * SECURITY CRITICAL: DeviceService Test Suite
+ *
+ * This service manages device ID generation and storage.
+ * Security properties tested:
+ * 1. Device ID uniqueness and unpredictability
+ * 2. Device identity persistence across sessions
+ * 3. Secure cleanup when needed
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DeviceService } from './device';
+
+// Test constants
+const TEST_DEVICE_ID = '123e4567-e89b-12d3-a456-426614174000';
+const DEVICE_ID_KEY = 'device-id';
+
+describe('DeviceService - Security Critical Tests', () => {
+  let service: DeviceService;
+  let mockLocalStorage: {
+    getItem: ReturnType<typeof vi.fn>;
+    setItem: ReturnType<typeof vi.fn>;
+    removeItem: ReturnType<typeof vi.fn>;
+    clear: ReturnType<typeof vi.fn>;
+    key: ReturnType<typeof vi.fn>;
+    length: number;
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Mock browser APIs
+    mockLocalStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      key: vi.fn(),
+      length: 0,
+    };
+
+    vi.stubGlobal('crypto', {
+      randomUUID: vi.fn().mockReturnValue(TEST_DEVICE_ID),
+    });
+
+    vi.stubGlobal('localStorage', mockLocalStorage);
+
+    service = new DeviceService();
+
+    // Suppress console output in tests
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  describe('Device ID Generation - Isolation Foundation', () => {
+    it('SECURITY: Should generate cryptographically random device ID when none exists', () => {
+      // SECURITY PROPERTY: Each device gets a unique, unpredictable identifier
+      mockLocalStorage.getItem.mockReturnValueOnce(null);
+
+      const result = service.getId();
+
+      expect(crypto.randomUUID).toHaveBeenCalled();
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(DEVICE_ID_KEY, TEST_DEVICE_ID);
+      expect(result).toBe(TEST_DEVICE_ID);
+    });
+
+    it('SECURITY: Should reuse existing device ID to maintain device identity', () => {
+      // SECURITY PROPERTY: Device identity persists across sessions
+      mockLocalStorage.getItem.mockReturnValueOnce(TEST_DEVICE_ID);
+
+      const result = service.getId();
+
+      expect(crypto.randomUUID).not.toHaveBeenCalled();
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
+      expect(result).toBe(TEST_DEVICE_ID);
+    });
+
+    it('SECURITY: Should generate new device ID each time when none exists in storage', () => {
+      // SECURITY PROPERTY: Multiple calls without existing storage create unique IDs
+      const firstDeviceId = '123e4567-e89b-12d3-a456-426614174001';
+      const secondDeviceId = '123e4567-e89b-12d3-a456-426614174002';
+
+      mockLocalStorage.getItem.mockReturnValue(null);
+      vi.mocked(crypto.randomUUID)
+        .mockReturnValueOnce(firstDeviceId)
+        .mockReturnValueOnce(secondDeviceId);
+
+      const result1 = service.getId();
+      const result2 = service.getId();
+
+      expect(crypto.randomUUID).toHaveBeenCalledTimes(2);
+      expect(result1).toBe(firstDeviceId);
+      expect(result2).toBe(secondDeviceId);
+    });
+  });
+
+  describe('Device ID Cleanup - Security Operations', () => {
+    it('SECURITY: Should clear device ID from storage for security cleanup', () => {
+      // SECURITY PROPERTY: Device ID can be securely removed when needed
+      service.clearId();
+
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(DEVICE_ID_KEY);
+    });
+
+    it('SECURITY: Should handle multiple clear operations safely', () => {
+      // SECURITY PROPERTY: Multiple clears don't cause errors
+      service.clearId();
+      service.clearId();
+
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledTimes(2);
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(DEVICE_ID_KEY);
+    });
+  });
+
+  describe('Device ID Persistence', () => {
+    it('Should maintain device identity across service instances', () => {
+      // SECURITY PROPERTY: Device identity is consistent across service recreations
+      mockLocalStorage.getItem.mockReturnValue(TEST_DEVICE_ID);
+
+      const service1 = new DeviceService();
+      const service2 = new DeviceService();
+
+      const id1 = service1.getId();
+      const id2 = service2.getId();
+
+      expect(id1).toBe(TEST_DEVICE_ID);
+      expect(id2).toBe(TEST_DEVICE_ID);
+      expect(crypto.randomUUID).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/device.ts
+++ b/src/services/device.ts
@@ -1,0 +1,29 @@
+import { XMIFService } from './service';
+
+const DEVICE_ID_KEY = 'device-id';
+
+export class DeviceService extends XMIFService {
+  name = 'Device Service';
+  log_prefix = '[DeviceService]';
+
+  public getId(): string {
+    this.log('Attempting to get device ID from storage');
+
+    const existing = localStorage.getItem(DEVICE_ID_KEY);
+    if (existing != null) {
+      this.log(`Found existing device ID: ${existing.substring(0, 8)}...`);
+      return existing;
+    }
+
+    this.log('No existing device ID found, generating new one');
+    const deviceId = crypto.randomUUID();
+    localStorage.setItem(DEVICE_ID_KEY, deviceId);
+    this.log(`Successfully stored new device ID: ${deviceId.substring(0, 8)}...`);
+    return deviceId;
+  }
+
+  public clearId(): void {
+    this.log('Clearing device ID from storage');
+    localStorage.removeItem(DEVICE_ID_KEY);
+  }
+}

--- a/src/services/handlers.test.ts
+++ b/src/services/handlers.test.ts
@@ -29,7 +29,7 @@ describe('EventHandlers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockServices.sharding.getDeviceId.mockReturnValue(TEST_FIXTURES.deviceId);
+    mockServices.device.getId.mockReturnValue(TEST_FIXTURES.deviceId);
     mockServices.attestation.getAttestedPublicKey.mockResolvedValue('mock-attestation-public-key');
   });
 

--- a/src/services/handlers.test.ts
+++ b/src/services/handlers.test.ts
@@ -30,9 +30,7 @@ describe('EventHandlers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockServices.sharding.getDeviceId.mockReturnValue(TEST_FIXTURES.deviceId);
-    mockServices.attestation.getPublicKeyFromAttestation.mockResolvedValue(
-      'mock-attestation-public-key'
-    );
+    mockServices.attestation.getAttestedPublicKey.mockResolvedValue('mock-attestation-public-key');
   });
 
   describe('StartOnboardingEventHandler', () => {
@@ -43,7 +41,6 @@ describe('EventHandlers', () => {
         data: { authId: 'test-auth-id' },
       };
 
-      mockServices.sharding.status.mockReturnValue('ready');
       mockServices.sharding.reconstructMasterSecret.mockResolvedValue(TEST_FIXTURES.masterSecret);
       mockServices.cryptoKey.getPublicKeyFromSeed.mockResolvedValue({
         bytes: TEST_FIXTURES.publicKey,
@@ -72,7 +69,8 @@ describe('EventHandlers', () => {
       mockServices.fpe.decrypt.mockResolvedValue([1, 2, 3, 4, 5, 6]);
 
       mockServices.api.completeOnboarding.mockResolvedValue({
-        shares: TEST_FIXTURES.shares,
+        deviceKeyShare: TEST_FIXTURES.shares.device,
+        signerId: 'test-signer-id',
       });
 
       mockServices.sharding.reconstructMasterSecret.mockResolvedValue(TEST_FIXTURES.masterSecret);
@@ -102,6 +100,7 @@ describe('EventHandlers', () => {
       );
 
       expect(mockServices.sharding.storeDeviceShare).toHaveBeenCalledWith(
+        'test-signer-id',
         TEST_FIXTURES.shares.device
       );
       expect(result).toHaveProperty('publicKeys');

--- a/src/services/handlers.ts
+++ b/src/services/handlers.ts
@@ -69,7 +69,7 @@ export class StartOnboardingEventHandler extends EventHandler<'start-onboarding'
         encryptionContext: {
           publicKey: await this.services.encrypt.getPublicKey(),
         },
-        deviceId: this.services.sharding.getDeviceId(),
+        deviceId: this.services.device.getId(),
       },
       payload.authData
     );
@@ -88,7 +88,7 @@ export class CompleteOnboardingEventHandler extends EventHandler<'complete-onboa
   async handler(
     payload: SignerInputEvent<'complete-onboarding'>
   ): Promise<SuccessfulOutputEvent<'complete-onboarding'>> {
-    const deviceId = this.services.sharding.getDeviceId();
+    const deviceId = this.services.device.getId();
     const encryptedOtp = payload.data.onboardingAuthentication.encryptedOtp;
     console.log(
       `[DEBUG, ${this.event} handler] Received encrypted OTP: ${encryptedOtp}. Decrypting`

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,6 +9,7 @@ import { FPEService } from './fpe';
 import { Secp256k1Service } from './secp256k1';
 import { CryptoKeyService } from './crypto-key';
 import { AuthShareCache } from './auth-share-cache';
+import { DeviceService } from './device';
 
 /**
  * Services index - Export all services
@@ -26,6 +27,7 @@ export type XMIFServices = {
   secp256k1: Secp256k1Service;
   fpe: FPEService;
   cryptoKey: CryptoKeyService;
+  device: DeviceService;
 };
 
 export const createXMIFServices = () => {
@@ -35,7 +37,11 @@ export const createXMIFServices = () => {
   const secp256k1Service = new Secp256k1Service();
   const crossmintApiService = new CrossmintApiService(encryptionService);
   const attestationService = new AttestationService(crossmintApiService);
-  const shardingService = new ShardingService(new AuthShareCache(crossmintApiService));
+  const deviceService = new DeviceService();
+  const shardingService = new ShardingService(
+    new AuthShareCache(crossmintApiService),
+    deviceService
+  );
   const fpeService = new FPEService(encryptionService);
   const cryptoKeyService = new CryptoKeyService(ed25519Service, secp256k1Service);
 
@@ -51,6 +57,7 @@ export const createXMIFServices = () => {
     sharding: shardingService,
     fpe: fpeService,
     cryptoKey: cryptoKeyService,
+    device: deviceService,
   } satisfies Record<string, XMIFService>;
   return services;
 };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,6 +8,7 @@ import type { XMIFService } from './service';
 import { FPEService } from './fpe';
 import { Secp256k1Service } from './secp256k1';
 import { CryptoKeyService } from './crypto-key';
+import { AuthShareCache } from './auth-share-cache';
 
 /**
  * Services index - Export all services
@@ -34,7 +35,7 @@ export const createXMIFServices = () => {
   const secp256k1Service = new Secp256k1Service();
   const crossmintApiService = new CrossmintApiService(encryptionService);
   const attestationService = new AttestationService(crossmintApiService);
-  const shardingService = new ShardingService(crossmintApiService);
+  const shardingService = new ShardingService(new AuthShareCache(crossmintApiService));
   const fpeService = new FPEService(encryptionService);
   const cryptoKeyService = new CryptoKeyService(ed25519Service, secp256k1Service);
 

--- a/src/services/sharding.test.ts
+++ b/src/services/sharding.test.ts
@@ -1,185 +1,416 @@
+/**
+ * SECURITY CRITICAL: ShardingService Test Suite
+ *
+ * This service handles Shamir Secret Sharing for cryptographic keys.
+ * Security properties tested:
+ * 1. Device ID isolation and generation
+ * 2. Master secret reconstruction from auth + device shares
+ * 3. Device share integrity validation via hash consistency
+ * 4. Multi-signer isolation (no cross-contamination between signers)
+ * 5. Secure cleanup on integrity failures
+ */
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+import type { MockProxy } from 'vitest-mock-extended';
 import { ShardingService } from './sharding';
-import { createMockServices } from '../tests/test-utils';
+import type { AuthShareCache } from './auth-share-cache';
 import { XMIFCodedError } from './error';
 
+// Test constants
 const MOCK_MASTER_SECRET = new Uint8Array(32).fill(1);
-
 const TEST_DEVICE_ID = 'test-device-id';
 const TEST_DEVICE_SHARE = 'test-device-share-base64';
-const TEST_AUTH_SHARE = 'test-auth-share-base64';
-const TEST_AUTH_DATA = {
-  jwt: 'test-jwt',
-  apiKey: 'test-api-key',
-};
+const TEST_SIGNER_ID = 'test-signer-id';
+const TEST_AUTH_DATA = { jwt: 'test-jwt', apiKey: 'test-api-key' };
 
-// Constants from the sharding service
+// Storage keys from the service
 const DEVICE_SHARE_KEY = 'device-share';
 const DEVICE_ID_KEY = 'device-id';
 
+// Mock Shamir secret sharing
 vi.mock('shamir-secret-sharing', () => ({
   combine: vi.fn().mockImplementation(() => Promise.resolve(MOCK_MASTER_SECRET)),
 }));
 
 import * as shamir from 'shamir-secret-sharing';
-import { subtle } from 'crypto';
-
 const mockCombine = shamir.combine as ReturnType<typeof vi.fn>;
 
-describe('ShardingService', () => {
-  const mockServices = createMockServices();
-
-  const mockLocalStorage = {
-    getItem: vi.fn(),
-    setItem: vi.fn(),
-    removeItem: vi.fn(),
-    clear: vi.fn(),
-    length: 0,
-    key: vi.fn(),
-  };
-
-  const mockSessionStorage = {
-    getItem: vi.fn(),
-    setItem: vi.fn(),
-    removeItem: vi.fn(),
-    clear: vi.fn(),
-    length: 0,
-    key: vi.fn(),
-  };
-
+describe('ShardingService - Security Critical Tests', () => {
   let service: ShardingService;
+  let mockAuthShareCache: MockProxy<AuthShareCache>;
+  let mockLocalStorage: {
+    getItem: ReturnType<typeof vi.fn>;
+    setItem: ReturnType<typeof vi.fn>;
+    removeItem: ReturnType<typeof vi.fn>;
+    clear: ReturnType<typeof vi.fn>;
+    key: ReturnType<typeof vi.fn>;
+    length: number;
+  };
 
   beforeEach(() => {
     vi.resetAllMocks();
+    mockCombine.mockClear().mockImplementation(() => Promise.resolve(MOCK_MASTER_SECRET));
 
-    mockCombine.mockClear();
-    mockCombine.mockImplementation(() => Promise.resolve(MOCK_MASTER_SECRET));
-
-    // Create a mock ArrayBuffer that will convert to "h(xyz)" when base64 encoded
-    const mockDigestResult = new Uint8Array([104, 40, 120, 121, 122, 41]).buffer;
+    // Mock browser APIs
+    mockLocalStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      key: vi.fn(),
+      length: 0,
+    };
 
     vi.stubGlobal('crypto', {
       randomUUID: vi.fn().mockReturnValue(TEST_DEVICE_ID),
-      subtle: { digest: vi.fn().mockResolvedValue(mockDigestResult) },
+      subtle: {
+        digest: vi.fn().mockResolvedValue(new Uint8Array([104, 40, 120, 121, 122, 41]).buffer),
+      },
     });
 
     vi.stubGlobal('localStorage', mockLocalStorage);
-    vi.stubGlobal('sessionStorage', mockSessionStorage);
-
-    // Mock the base64 conversion functions
     vi.stubGlobal(
       'atob',
       vi.fn(() => 'ABCD')
     );
-
     vi.stubGlobal(
       'btoa',
       vi.fn(() => 'h(xyz)')
     );
 
-    service = new ShardingService(mockServices.api);
+    // Mock dependencies
+    mockAuthShareCache = mock<AuthShareCache>();
+    service = new ShardingService(mockAuthShareCache);
 
+    // Suppress console output in tests
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'debug').mockImplementation(() => {});
   });
 
-  // Only keeping essential tests for device identity management
-  it('should generate and store a new device ID if none exists', () => {
-    mockLocalStorage.getItem.mockReturnValueOnce(null);
+  describe('Device ID Management - Isolation Foundation', () => {
+    it('SECURITY: Should generate cryptographically random device ID when none exists', () => {
+      // SECURITY PROPERTY: Each device gets a unique, unpredictable identifier
+      mockLocalStorage.getItem.mockReturnValueOnce(null);
 
-    const result = service.getDeviceId();
+      const result = service.getDeviceId();
 
-    expect(crypto.randomUUID).toHaveBeenCalled();
-    expect(mockLocalStorage.setItem).toHaveBeenCalledWith('device-id', TEST_DEVICE_ID);
-    expect(result).toBe(TEST_DEVICE_ID);
+      expect(crypto.randomUUID).toHaveBeenCalled();
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(DEVICE_ID_KEY, TEST_DEVICE_ID);
+      expect(result).toBe(TEST_DEVICE_ID);
+    });
+
+    it('SECURITY: Should reuse existing device ID to maintain device identity', () => {
+      // SECURITY PROPERTY: Device identity persists across sessions
+      mockLocalStorage.getItem.mockReturnValueOnce(TEST_DEVICE_ID);
+
+      const result = service.getDeviceId();
+
+      expect(crypto.randomUUID).not.toHaveBeenCalled();
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
+      expect(result).toBe(TEST_DEVICE_ID);
+    });
   });
 
-  // Keeping the most complex test that covers the core functionality
-  describe('getMasterSecret', () => {
+  describe('Master Secret Reconstruction - Core Security Function', () => {
     beforeEach(() => {
+      // Default setup: valid device share exists
       mockLocalStorage.getItem.mockImplementation(key => {
-        if (key === 'device-share') return TEST_DEVICE_SHARE;
-        if (key === 'device-id') return TEST_DEVICE_ID;
+        if (key === `${DEVICE_SHARE_KEY}-${TEST_SIGNER_ID}`) return TEST_DEVICE_SHARE;
+        if (key === DEVICE_ID_KEY) return TEST_DEVICE_ID;
         return null;
       });
     });
 
-    it('should handle the complete flow of fetching and combining shares', async () => {
-      // Test the case where auth share is not cached
-      mockSessionStorage.getItem.mockReturnValueOnce(null);
-      mockServices.api.getAuthShard.mockResolvedValueOnce({
-        deviceId: TEST_DEVICE_ID,
-        keyShare: TEST_AUTH_SHARE,
-        deviceKeyShareHash: 'h(xyz)',
+    it('SECURITY: Should successfully reconstruct master secret from valid shares', async () => {
+      // SECURITY PROPERTY: Valid auth + device shares = master secret
+      mockAuthShareCache.getAuthShare.mockResolvedValueOnce({
+        authKeyShare: 'test-auth-share',
+        deviceKeyShareHash: 'h(xyz)', // Matches our btoa mock
+        signerId: TEST_SIGNER_ID,
       });
 
       const result = await service.reconstructMasterSecret(TEST_AUTH_DATA);
-      expect(mockServices.api.getAuthShard).toHaveBeenCalledWith(
-        TEST_DEVICE_ID,
-        undefined,
-        TEST_AUTH_DATA
-      );
 
-      // Verify the shares were combined
+      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(TEST_DEVICE_ID, TEST_AUTH_DATA);
       expect(mockCombine).toHaveBeenCalledWith(
         expect.arrayContaining([expect.anything(), expect.anything()])
       );
       expect(result).toEqual(MOCK_MASTER_SECRET);
     });
 
-    it('should throw error if device share is not found', async () => {
+    it('SECURITY: Should fail safely when auth share is unavailable', async () => {
+      // SECURITY PROPERTY: Missing auth share = no secret reconstruction
+      mockAuthShareCache.getAuthShare.mockResolvedValueOnce(null);
+
+      const result = await service.reconstructMasterSecret(TEST_AUTH_DATA);
+
+      expect(result).toBeNull();
+      expect(mockCombine).not.toHaveBeenCalled();
+    });
+
+    it('SECURITY: Should fail safely when device share is missing', async () => {
+      // SECURITY PROPERTY: Missing device share = no secret reconstruction
+      mockAuthShareCache.getAuthShare.mockResolvedValueOnce({
+        authKeyShare: 'test-auth-share',
+        deviceKeyShareHash: 'h(xyz)',
+        signerId: TEST_SIGNER_ID,
+      });
+
       mockLocalStorage.getItem.mockImplementation(key => {
-        if (key === 'device-id') return TEST_DEVICE_ID;
+        if (key === DEVICE_ID_KEY) return TEST_DEVICE_ID;
+        return null; // No device share
+      });
+
+      const result = await service.reconstructMasterSecret(TEST_AUTH_DATA);
+
+      expect(result).toBeNull();
+      expect(mockCombine).not.toHaveBeenCalled();
+    });
+
+    it('SECURITY: Should handle cryptographic failures gracefully', async () => {
+      // SECURITY PROPERTY: Shamir reconstruction errors are properly handled
+      mockAuthShareCache.getAuthShare.mockResolvedValueOnce({
+        authKeyShare: 'test-auth-share',
+        deviceKeyShareHash: 'h(xyz)',
+        signerId: TEST_SIGNER_ID,
+      });
+
+      mockCombine.mockRejectedValueOnce(new Error('Invalid share format'));
+
+      await expect(service.reconstructMasterSecret(TEST_AUTH_DATA)).rejects.toThrow(
+        'Failed to recombine key shards: Invalid share format'
+      );
+    });
+  });
+
+  describe('Device Share Integrity Validation - Tampering Detection', () => {
+    it('SECURITY: Should detect and respond to device share tampering', async () => {
+      // SECURITY PROPERTY: Hash mismatch = potential tampering = secure cleanup
+      vi.stubGlobal(
+        'btoa',
+        vi.fn(() => 'tampered-hash')
+      );
+
+      mockLocalStorage.getItem.mockImplementation(key => {
+        if (key === `${DEVICE_SHARE_KEY}-${TEST_SIGNER_ID}`) return TEST_DEVICE_SHARE;
+        if (key === DEVICE_ID_KEY) return TEST_DEVICE_ID;
         return null;
       });
 
-      await expect(service.reconstructMasterSecret(TEST_AUTH_DATA)).rejects.toThrow(
-        'Device share not found'
-      );
-    });
-
-    it('should handle share combination failures', async () => {
-      // Mock API response first to avoid destructuring error
-      mockServices.api.getAuthShard.mockResolvedValueOnce({
-        deviceId: TEST_DEVICE_ID,
-        keyShare: TEST_AUTH_SHARE,
-        deviceKeyShareHash: 'h(xyz)',
+      mockAuthShareCache.getAuthShare.mockResolvedValueOnce({
+        authKeyShare: 'test-auth-share',
+        deviceKeyShareHash: 'expected-hash', // Different from tampered-hash
+        signerId: TEST_SIGNER_ID,
       });
 
-      // Then make combine throw the expected error
-      mockCombine.mockRejectedValueOnce(new Error('Failed to combine shares'));
+      await expect(service.reconstructMasterSecret(TEST_AUTH_DATA)).rejects.toThrow(XMIFCodedError);
 
-      await expect(service.reconstructMasterSecret(TEST_AUTH_DATA)).rejects.toThrow(
-        'Failed to combine shares'
+      // SECURITY CRITICAL: Verify complete cleanup on tampering detection
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+        `${DEVICE_SHARE_KEY}-${TEST_SIGNER_ID}`
+      );
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(DEVICE_ID_KEY);
+      expect(mockAuthShareCache.clearCache).toHaveBeenCalled();
+    });
+  });
+
+  describe('Device Share Storage', () => {
+    it('Should store device share with correct signer isolation', () => {
+      // SECURITY PROPERTY: Each signer gets isolated storage
+      service.storeDeviceShare(TEST_SIGNER_ID, TEST_DEVICE_SHARE);
+
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        `${DEVICE_SHARE_KEY}-${TEST_SIGNER_ID}`,
+        TEST_DEVICE_SHARE
       );
     });
+  });
 
-    it('should throw error when device share hash does not match', async () => {
-      // Override the btoa mock to return a different hash value
-      vi.stubGlobal(
-        'btoa',
-        vi.fn(() => 'mismatched-hash')
-      );
+  describe('Multi-Signer Isolation - Cross-Contamination Prevention', () => {
+    // SECURITY CRITICAL: These tests verify that multiple signers cannot access each other's data
 
-      // Mock API to return a different hash than what our device generates
-      mockServices.api.getAuthShard.mockResolvedValue({
-        deviceId: TEST_DEVICE_ID,
-        keyShare: TEST_AUTH_SHARE,
-        deviceKeyShareHash: 'expected-hash', // Different from what btoa returns
+    const SIGNER_SCENARIOS = {
+      signer1: {
+        authData: { jwt: 'signer1-jwt', apiKey: 'signer1-api-key' },
+        signerId: 'signer-1',
+        deviceShare: 'device-share-1-base64',
+        authShare: 'auth-share-1-base64',
+      },
+      signer2: {
+        authData: { jwt: 'signer2-jwt', apiKey: 'signer2-api-key' },
+        signerId: 'signer-2',
+        deviceShare: 'device-share-2-base64',
+        authShare: 'auth-share-2-base64',
+      },
+      signer3: {
+        authData: { jwt: 'signer3-jwt', apiKey: 'signer1-api-key' }, // Same API, different JWT
+        signerId: 'signer-3',
+        deviceShare: 'device-share-3-base64',
+        authShare: 'auth-share-3-base64',
+      },
+    };
+
+    beforeEach(() => {
+      // Setup isolated storage for each signer
+      mockLocalStorage.getItem.mockImplementation(key => {
+        if (key === DEVICE_ID_KEY) return TEST_DEVICE_ID;
+        if (key === `${DEVICE_SHARE_KEY}-${SIGNER_SCENARIOS.signer1.signerId}`)
+          return SIGNER_SCENARIOS.signer1.deviceShare;
+        if (key === `${DEVICE_SHARE_KEY}-${SIGNER_SCENARIOS.signer2.signerId}`)
+          return SIGNER_SCENARIOS.signer2.deviceShare;
+        if (key === `${DEVICE_SHARE_KEY}-${SIGNER_SCENARIOS.signer3.signerId}`)
+          return SIGNER_SCENARIOS.signer3.deviceShare;
+        return null;
       });
 
-      try {
-        await service.reconstructMasterSecret(TEST_AUTH_DATA);
-        expect.fail('Should have thrown an error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(XMIFCodedError);
-        expect((error as XMIFCodedError).code).toBe('invalid-device-share');
-        expect((error as Error).message).toMatch(/Key share stored on this device does not match/);
+      // Setup isolated auth share responses
+      mockAuthShareCache.getAuthShare.mockImplementation(async (deviceId, authData) => {
+        const scenario = Object.values(SIGNER_SCENARIOS).find(
+          s => s.authData.jwt === authData.jwt && s.authData.apiKey === authData.apiKey
+        );
+
+        if (scenario) {
+          return {
+            authKeyShare: scenario.authShare,
+            deviceKeyShareHash: 'h(xyz)',
+            signerId: scenario.signerId,
+          };
+        }
+
+        throw new Error(`Unexpected auth data: ${JSON.stringify(authData)}`);
+      });
+    });
+
+    it('SECURITY: Should maintain complete isolation between multiple signers', async () => {
+      // SECURITY PROPERTY: Each signer can only access their own data
+
+      // Test all signers can reconstruct independently
+      const results = await Promise.all([
+        service.reconstructMasterSecret(SIGNER_SCENARIOS.signer1.authData),
+        service.reconstructMasterSecret(SIGNER_SCENARIOS.signer2.authData),
+        service.reconstructMasterSecret(SIGNER_SCENARIOS.signer3.authData),
+      ]);
+
+      // All should succeed with same result (in real use, would be different keys)
+      for (const result of results) {
+        expect(result).toEqual(MOCK_MASTER_SECRET);
       }
 
-      // Verify localStorage items were removed
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(DEVICE_SHARE_KEY);
+      // Verify correct isolation: each signer's auth data called exactly once
+      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledTimes(3);
+      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+        TEST_DEVICE_ID,
+        SIGNER_SCENARIOS.signer1.authData
+      );
+      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+        TEST_DEVICE_ID,
+        SIGNER_SCENARIOS.signer2.authData
+      );
+      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+        TEST_DEVICE_ID,
+        SIGNER_SCENARIOS.signer3.authData
+      );
+
+      // Verify correct device share isolation
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith(
+        `${DEVICE_SHARE_KEY}-${SIGNER_SCENARIOS.signer1.signerId}`
+      );
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith(
+        `${DEVICE_SHARE_KEY}-${SIGNER_SCENARIOS.signer2.signerId}`
+      );
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith(
+        `${DEVICE_SHARE_KEY}-${SIGNER_SCENARIOS.signer3.signerId}`
+      );
+    });
+
+    it('SECURITY: Should isolate errors - one signer failure cannot affect others', async () => {
+      // SECURITY PROPERTY: Signer errors are isolated
+      mockAuthShareCache.getAuthShare.mockImplementation(async (deviceId, authData) => {
+        if (authData.jwt === SIGNER_SCENARIOS.signer1.authData.jwt) {
+          throw new Error('Signer 1 auth error');
+        }
+        if (authData.jwt === SIGNER_SCENARIOS.signer2.authData.jwt) {
+          return {
+            authKeyShare: SIGNER_SCENARIOS.signer2.authShare,
+            deviceKeyShareHash: 'h(xyz)',
+            signerId: SIGNER_SCENARIOS.signer2.signerId,
+          };
+        }
+        throw new Error('Unexpected auth data');
+      });
+
+      // Signer 1 should fail
+      await expect(
+        service.reconstructMasterSecret(SIGNER_SCENARIOS.signer1.authData)
+      ).rejects.toThrow('Signer 1 auth error');
+
+      // Signer 2 should still work
+      const result2 = await service.reconstructMasterSecret(SIGNER_SCENARIOS.signer2.authData);
+      expect(result2).toEqual(MOCK_MASTER_SECRET);
+    });
+
+    it('SECURITY: Should handle missing device share for one signer without affecting others', async () => {
+      // SECURITY PROPERTY: Missing shares are isolated per signer
+      mockLocalStorage.getItem.mockImplementation(key => {
+        if (key === DEVICE_ID_KEY) return TEST_DEVICE_ID;
+        if (key === `${DEVICE_SHARE_KEY}-${SIGNER_SCENARIOS.signer1.signerId}`) return null; // Missing
+        if (key === `${DEVICE_SHARE_KEY}-${SIGNER_SCENARIOS.signer2.signerId}`)
+          return SIGNER_SCENARIOS.signer2.deviceShare;
+        return null;
+      });
+
+      // Signer 1 should return null (missing device share)
+      const result1 = await service.reconstructMasterSecret(SIGNER_SCENARIOS.signer1.authData);
+      expect(result1).toBeNull();
+
+      // Signer 2 should still work normally
+      const result2 = await service.reconstructMasterSecret(SIGNER_SCENARIOS.signer2.authData);
+      expect(result2).toEqual(MOCK_MASTER_SECRET);
+    });
+
+    it('SECURITY: Should isolate tampering cleanup to affected signer only', async () => {
+      // SECURITY PROPERTY: Tampering detection cleanup is signer-specific
+      mockAuthShareCache.getAuthShare.mockImplementation(async (deviceId, authData) => {
+        if (authData.jwt === SIGNER_SCENARIOS.signer1.authData.jwt) {
+          return {
+            authKeyShare: SIGNER_SCENARIOS.signer1.authShare,
+            deviceKeyShareHash: 'different-hash', // Hash mismatch = tampering
+            signerId: SIGNER_SCENARIOS.signer1.signerId,
+          };
+        }
+        if (authData.jwt === SIGNER_SCENARIOS.signer2.authData.jwt) {
+          return {
+            authKeyShare: SIGNER_SCENARIOS.signer2.authShare,
+            deviceKeyShareHash: 'h(xyz)', // Valid hash
+            signerId: SIGNER_SCENARIOS.signer2.signerId,
+          };
+        }
+        throw new Error('Unexpected auth data');
+      });
+
+      // Signer 1 should fail with tampering error
+      await expect(
+        service.reconstructMasterSecret(SIGNER_SCENARIOS.signer1.authData)
+      ).rejects.toThrow(/Key share stored on this device does not match/);
+
+      // Verify cleanup occurred
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+        `${DEVICE_SHARE_KEY}-${SIGNER_SCENARIOS.signer1.signerId}`
+      );
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(DEVICE_ID_KEY);
+      expect(mockAuthShareCache.clearCache).toHaveBeenCalled();
+
+      // Signer 2 should still work after device ID regeneration
+      mockLocalStorage.getItem.mockImplementation(key => {
+        if (key === DEVICE_ID_KEY) return TEST_DEVICE_ID;
+        if (key === `${DEVICE_SHARE_KEY}-${SIGNER_SCENARIOS.signer2.signerId}`)
+          return SIGNER_SCENARIOS.signer2.deviceShare;
+        return null;
+      });
+
+      const result2 = await service.reconstructMasterSecret(SIGNER_SCENARIOS.signer2.authData);
+      expect(result2).toEqual(MOCK_MASTER_SECRET);
     });
   });
 });

--- a/src/services/sharding.test.ts
+++ b/src/services/sharding.test.ts
@@ -101,7 +101,7 @@ describe('ShardingService - Security Critical Tests', () => {
     });
 
     it('SECURITY: Should successfully reconstruct master secret from valid shares', async () => {
-      mockAuthShareCache.getAuthShare.mockResolvedValueOnce({
+      mockAuthShareCache.get.mockResolvedValueOnce({
         authKeyShare: 'test-auth-share',
         deviceKeyShareHash: 'h(xyz)', // Matches our btoa mock
         signerId: TEST_SIGNER_ID,
@@ -109,7 +109,7 @@ describe('ShardingService - Security Critical Tests', () => {
 
       const result = await service.reconstructMasterSecret(TEST_AUTH_DATA);
 
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(TEST_DEVICE_ID, TEST_AUTH_DATA);
+      expect(mockAuthShareCache.get).toHaveBeenCalledWith(TEST_DEVICE_ID, TEST_AUTH_DATA);
       expect(mockCombine).toHaveBeenCalledWith(
         expect.arrayContaining([expect.anything(), expect.anything()])
       );
@@ -117,7 +117,7 @@ describe('ShardingService - Security Critical Tests', () => {
     });
 
     it('SECURITY: Should fail safely when auth share is unavailable', async () => {
-      mockAuthShareCache.getAuthShare.mockResolvedValueOnce(null);
+      mockAuthShareCache.get.mockResolvedValueOnce(null);
 
       const result = await service.reconstructMasterSecret(TEST_AUTH_DATA);
 
@@ -126,7 +126,7 @@ describe('ShardingService - Security Critical Tests', () => {
     });
 
     it('SECURITY: Should fail safely when device share is missing', async () => {
-      mockAuthShareCache.getAuthShare.mockResolvedValueOnce({
+      mockAuthShareCache.get.mockResolvedValueOnce({
         authKeyShare: 'test-auth-share',
         deviceKeyShareHash: 'h(xyz)',
         signerId: TEST_SIGNER_ID,
@@ -143,7 +143,7 @@ describe('ShardingService - Security Critical Tests', () => {
     });
 
     it('SECURITY: Should handle cryptographic failures gracefully', async () => {
-      mockAuthShareCache.getAuthShare.mockResolvedValueOnce({
+      mockAuthShareCache.get.mockResolvedValueOnce({
         authKeyShare: 'test-auth-share',
         deviceKeyShareHash: 'h(xyz)',
         signerId: TEST_SIGNER_ID,
@@ -169,7 +169,7 @@ describe('ShardingService - Security Critical Tests', () => {
         return null;
       });
 
-      mockAuthShareCache.getAuthShare.mockResolvedValueOnce({
+      mockAuthShareCache.get.mockResolvedValueOnce({
         authKeyShare: 'test-auth-share',
         deviceKeyShareHash: 'expected-hash', // Different from tampered-hash
         signerId: TEST_SIGNER_ID,
@@ -234,7 +234,7 @@ describe('ShardingService - Security Critical Tests', () => {
       });
 
       // Setup isolated auth share responses
-      mockAuthShareCache.getAuthShare.mockImplementation(async (deviceId, authData) => {
+      mockAuthShareCache.get.mockImplementation(async (deviceId, authData) => {
         const scenario = Object.values(SIGNER_SCENARIOS).find(
           s => s.authData.jwt === authData.jwt && s.authData.apiKey === authData.apiKey
         );
@@ -266,8 +266,8 @@ describe('ShardingService - Security Critical Tests', () => {
       );
 
       // Verify only signer 1's auth share was accessed
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledTimes(1);
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+      expect(mockAuthShareCache.get).toHaveBeenCalledTimes(1);
+      expect(mockAuthShareCache.get).toHaveBeenCalledWith(
         TEST_DEVICE_ID,
         SIGNER_SCENARIOS.signer1.authData
       );
@@ -286,8 +286,8 @@ describe('ShardingService - Security Critical Tests', () => {
       );
 
       // Verify only signer 2's auth share was accessed
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledTimes(1);
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+      expect(mockAuthShareCache.get).toHaveBeenCalledTimes(1);
+      expect(mockAuthShareCache.get).toHaveBeenCalledWith(
         TEST_DEVICE_ID,
         SIGNER_SCENARIOS.signer2.authData
       );
@@ -306,8 +306,8 @@ describe('ShardingService - Security Critical Tests', () => {
       );
 
       // Verify only signer 3's auth share was accessed
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledTimes(1);
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+      expect(mockAuthShareCache.get).toHaveBeenCalledTimes(1);
+      expect(mockAuthShareCache.get).toHaveBeenCalledWith(
         TEST_DEVICE_ID,
         SIGNER_SCENARIOS.signer3.authData
       );
@@ -317,7 +317,7 @@ describe('ShardingService - Security Critical Tests', () => {
       // Clear all mocks to start fresh
       vi.clearAllMocks();
 
-      mockAuthShareCache.getAuthShare.mockImplementation(async (deviceId, authData) => {
+      mockAuthShareCache.get.mockImplementation(async (deviceId, authData) => {
         if (authData.jwt === SIGNER_SCENARIOS.signer1.authData.jwt) {
           throw new Error('Signer 1 auth error');
         }
@@ -337,8 +337,8 @@ describe('ShardingService - Security Critical Tests', () => {
       ).rejects.toThrow('Signer 1 auth error');
 
       // Verify signer 1's auth share was attempted
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledTimes(1);
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+      expect(mockAuthShareCache.get).toHaveBeenCalledTimes(1);
+      expect(mockAuthShareCache.get).toHaveBeenCalledWith(
         TEST_DEVICE_ID,
         SIGNER_SCENARIOS.signer1.authData
       );
@@ -354,8 +354,8 @@ describe('ShardingService - Security Critical Tests', () => {
       expect(result2).toEqual(MOCK_MASTER_SECRET);
 
       // Verify only signer 2's resources were accessed
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledTimes(1);
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+      expect(mockAuthShareCache.get).toHaveBeenCalledTimes(1);
+      expect(mockAuthShareCache.get).toHaveBeenCalledWith(
         TEST_DEVICE_ID,
         SIGNER_SCENARIOS.signer2.authData
       );
@@ -383,8 +383,8 @@ describe('ShardingService - Security Critical Tests', () => {
       expect(result1).toBeNull();
 
       // Verify signer 1's auth share was accessed
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledTimes(1);
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+      expect(mockAuthShareCache.get).toHaveBeenCalledTimes(1);
+      expect(mockAuthShareCache.get).toHaveBeenCalledWith(
         TEST_DEVICE_ID,
         SIGNER_SCENARIOS.signer1.authData
       );
@@ -403,8 +403,8 @@ describe('ShardingService - Security Critical Tests', () => {
       expect(result2).toEqual(MOCK_MASTER_SECRET);
 
       // Verify only signer 2's resources were accessed
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledTimes(1);
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+      expect(mockAuthShareCache.get).toHaveBeenCalledTimes(1);
+      expect(mockAuthShareCache.get).toHaveBeenCalledWith(
         TEST_DEVICE_ID,
         SIGNER_SCENARIOS.signer2.authData
       );
@@ -419,7 +419,7 @@ describe('ShardingService - Security Critical Tests', () => {
       // Clear all mocks to start fresh
       vi.clearAllMocks();
 
-      mockAuthShareCache.getAuthShare.mockImplementation(async (deviceId, authData) => {
+      mockAuthShareCache.get.mockImplementation(async (deviceId, authData) => {
         if (authData.jwt === SIGNER_SCENARIOS.signer1.authData.jwt) {
           return {
             authKeyShare: SIGNER_SCENARIOS.signer1.authShare,
@@ -443,8 +443,8 @@ describe('ShardingService - Security Critical Tests', () => {
       ).rejects.toThrow(/Key share stored on this device does not match/);
 
       // Verify the correct sequence of operations for signer 1
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledTimes(1);
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+      expect(mockAuthShareCache.get).toHaveBeenCalledTimes(1);
+      expect(mockAuthShareCache.get).toHaveBeenCalledWith(
         TEST_DEVICE_ID,
         SIGNER_SCENARIOS.signer1.authData
       );
@@ -477,8 +477,8 @@ describe('ShardingService - Security Critical Tests', () => {
       expect(result2).toEqual(MOCK_MASTER_SECRET);
 
       // Verify only signer 2's resources were accessed
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledTimes(1);
-      expect(mockAuthShareCache.getAuthShare).toHaveBeenCalledWith(
+      expect(mockAuthShareCache.get).toHaveBeenCalledTimes(1);
+      expect(mockAuthShareCache.get).toHaveBeenCalledWith(
         TEST_DEVICE_ID,
         SIGNER_SCENARIOS.signer2.authData
       );

--- a/src/services/sharding.test.ts
+++ b/src/services/sharding.test.ts
@@ -81,7 +81,7 @@ describe('ShardingService - Security Critical Tests', () => {
 
     // Mock dependencies
     mockAuthShareCache = mock<AuthShareCache>();
-    mockDeviceService = mock<import('./device').DeviceService>();
+    mockDeviceService = mock<DeviceService>();
     mockDeviceService.getId.mockReturnValue(TEST_DEVICE_ID);
 
     service = new ShardingService(mockAuthShareCache, mockDeviceService);
@@ -116,7 +116,7 @@ describe('ShardingService - Security Critical Tests', () => {
       expect(result).toEqual(MOCK_MASTER_SECRET);
     });
 
-    it('SECURITY: Should fail safely when auth share is unavailable', async () => {
+    it('SECURITY: Should return null when auth share is unavailable', async () => {
       mockAuthShareCache.get.mockResolvedValueOnce(null);
 
       const result = await service.reconstructMasterSecret(TEST_AUTH_DATA);

--- a/src/services/sharding.ts
+++ b/src/services/sharding.ts
@@ -72,7 +72,7 @@ export class ShardingService extends XMIFService {
    */
   public async reconstructMasterSecret(authData: { jwt: string; apiKey: string }) {
     const deviceId = this.deviceService.getId();
-    const authShardData = await this.authShareCache.getAuthShare(deviceId, authData);
+    const authShardData = await this.authShareCache.get(deviceId, authData);
     if (authShardData == null) {
       return null;
     }

--- a/src/services/sharding.ts
+++ b/src/services/sharding.ts
@@ -1,34 +1,24 @@
 import { combine } from 'shamir-secret-sharing';
 import { XMIFService } from './service';
-import type { CrossmintApiService } from './api';
 import { XMIFCodedError } from './error';
 import { decodeBytes, encodeBytes } from './utils';
-import { CrossmintHttpError } from './request';
+import type { AuthShareCache } from './auth-share-cache';
 
 const DEVICE_SHARE_KEY = 'device-share';
 const DEVICE_ID_KEY = 'device-id';
 const HASH_ALGO = 'SHA-256';
 
-interface AuthShardCacheEntry {
-  authKeyShare: string;
-  deviceKeyShareHash: string;
-  signerId: string;
-  timestamp: number;
-}
-
-// Chain agnostic secret sharding service
 export class ShardingService extends XMIFService {
   name = 'Sharding Service';
   log_prefix = '[ShardingService]';
 
-  private authShardCache = new Map<string, AuthShardCacheEntry>();
-  private readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-
-  constructor(private readonly api: CrossmintApiService) {
+  constructor(private readonly authShareCache: AuthShareCache) {
     super();
   }
 
-  async init() {}
+  async init() {
+    await this.authShareCache.init();
+  }
 
   public getDeviceId(): string {
     this.log('Attempting to get device ID from storage');
@@ -47,7 +37,8 @@ export class ShardingService extends XMIFService {
   }
 
   public async reconstructMasterSecret(authData: { jwt: string; apiKey: string }) {
-    const authShardData = await this.getAuthShard(authData);
+    const deviceId = this.getDeviceId();
+    const authShardData = await this.authShareCache.getAuthShare(deviceId, authData);
     if (authShardData == null) {
       return null;
     }
@@ -60,18 +51,7 @@ export class ShardingService extends XMIFService {
     }
 
     const deviceShareBytes = decodeBytes(deviceShare, 'base64');
-    const hashBuffer = await crypto.subtle.digest(HASH_ALGO, deviceShareBytes);
-    const reconstructedDeviceHashBase64 = encodeBytes(new Uint8Array(hashBuffer), 'base64');
-
-    if (reconstructedDeviceHashBase64 !== deviceKeyShareHash) {
-      this.clear(signerId);
-      throw new XMIFCodedError(
-        `Key share stored on this device does not match Crossmint held authentication share.
-Actual hash of local device share: ${reconstructedDeviceHashBase64}
-Expected hash from Crossmint: ${deviceKeyShareHash}`,
-        'invalid-device-share'
-      );
-    }
+    await this.validateDeviceShareConsistency(deviceShareBytes, deviceKeyShareHash, signerId);
 
     try {
       const authShareBytes = decodeBytes(authKeyShare, 'base64');
@@ -83,45 +63,22 @@ Expected hash from Crossmint: ${deviceKeyShareHash}`,
     }
   }
 
-  private async getAuthShard(authData: { jwt: string; apiKey: string }): Promise<{
-    authKeyShare: string;
-    deviceKeyShareHash: string;
-    signerId: string;
-  } | null> {
-    const deviceId = this.getDeviceId();
-    const cacheKey = `${deviceId}-${authData.apiKey}-${authData.jwt}`;
+  private async validateDeviceShareConsistency(
+    deviceShareBytes: Uint8Array,
+    expectedDeviceKeyShareHash: string,
+    signerId: string
+  ): Promise<void> {
+    const hashBuffer = await crypto.subtle.digest(HASH_ALGO, deviceShareBytes);
+    const reconstructedDeviceHashBase64 = encodeBytes(new Uint8Array(hashBuffer), 'base64');
 
-    const cached = this.authShardCache.get(cacheKey);
-    if (cached && Date.now() - cached.timestamp < this.CACHE_TTL_MS) {
-      this.log('Using cached auth shard');
-      return {
-        authKeyShare: cached.authKeyShare,
-        deviceKeyShareHash: cached.deviceKeyShareHash,
-        signerId: cached.signerId,
-      };
-    }
-
-    try {
-      this.log('Fetching auth shard from API');
-      const result = await this.api.getAuthShard(deviceId, undefined, authData);
-      this.authShardCache.set(cacheKey, {
-        authKeyShare: result.authKeyShare,
-        deviceKeyShareHash: result.deviceKeyShareHash,
-        signerId: result.signerId,
-        timestamp: Date.now(),
-      });
-
-      return {
-        authKeyShare: result.authKeyShare,
-        deviceKeyShareHash: result.deviceKeyShareHash,
-        signerId: result.signerId,
-      };
-    } catch (e) {
-      if (e instanceof CrossmintHttpError && e.status === 404) {
-        return null;
-      }
-
-      throw e;
+    if (reconstructedDeviceHashBase64 !== expectedDeviceKeyShareHash) {
+      this.clear(signerId);
+      throw new XMIFCodedError(
+        `Key share stored on this device does not match Crossmint held authentication share.
+Actual hash of local device share: ${reconstructedDeviceHashBase64}
+Expected hash from Crossmint: ${expectedDeviceKeyShareHash}`,
+        'invalid-device-share'
+      );
     }
   }
 
@@ -136,6 +93,6 @@ Expected hash from Crossmint: ${deviceKeyShareHash}`,
   private clear(signerId: string) {
     localStorage.removeItem(this.deviceShareStorageKey(signerId));
     localStorage.removeItem(DEVICE_ID_KEY);
-    this.authShardCache.clear();
+    this.authShareCache.clearCache();
   }
 }

--- a/src/services/sharding.ts
+++ b/src/services/sharding.ts
@@ -5,7 +5,6 @@ import { decodeBytes, encodeBytes } from './utils';
 import type { AuthShareCache } from './auth-share-cache';
 import type { DeviceService } from './device';
 
-const DEVICE_SHARE_KEY = 'device-share';
 const HASH_ALGO = 'SHA-256';
 
 export class ShardingService extends XMIFService {
@@ -21,6 +20,10 @@ export class ShardingService extends XMIFService {
 
   async init() {
     await this.authShareCache.init();
+  }
+
+  public storeDeviceShare(signerId: string, share: string): void {
+    localStorage.setItem(this.deviceShareStorageKey(signerId), share);
   }
 
   public async reconstructMasterSecret(authData: { jwt: string; apiKey: string }) {
@@ -50,10 +53,6 @@ export class ShardingService extends XMIFService {
     }
   }
 
-  public storeDeviceShare(signerId: string, share: string): void {
-    localStorage.setItem(this.deviceShareStorageKey(signerId), share);
-  }
-
   private async validateDeviceShareConsistency(
     deviceShareBytes: Uint8Array,
     expectedHashBase64: string,
@@ -74,7 +73,7 @@ Expected hash from Crossmint: ${expectedHashBase64}`,
   }
 
   private deviceShareStorageKey(signerId: string): string {
-    return `${DEVICE_SHARE_KEY}-${signerId}`;
+    return `device-share-${signerId}`;
   }
 
   private clear(signerId: string) {

--- a/src/services/sharding.ts
+++ b/src/services/sharding.ts
@@ -50,27 +50,27 @@ export class ShardingService extends XMIFService {
     }
   }
 
+  public storeDeviceShare(signerId: string, share: string): void {
+    localStorage.setItem(this.deviceShareStorageKey(signerId), share);
+  }
+
   private async validateDeviceShareConsistency(
     deviceShareBytes: Uint8Array,
-    expectedDeviceKeyShareHash: string,
+    expectedHashBase64: string,
     signerId: string
   ): Promise<void> {
     const hashBuffer = await crypto.subtle.digest(HASH_ALGO, deviceShareBytes);
     const reconstructedDeviceHashBase64 = encodeBytes(new Uint8Array(hashBuffer), 'base64');
 
-    if (reconstructedDeviceHashBase64 !== expectedDeviceKeyShareHash) {
+    if (reconstructedDeviceHashBase64 !== expectedHashBase64) {
       this.clear(signerId);
       throw new XMIFCodedError(
         `Key share stored on this device does not match Crossmint held authentication share.
 Actual hash of local device share: ${reconstructedDeviceHashBase64}
-Expected hash from Crossmint: ${expectedDeviceKeyShareHash}`,
+Expected hash from Crossmint: ${expectedHashBase64}`,
         'invalid-device-share'
       );
     }
-  }
-
-  public storeDeviceShare(signerId: string, share: string): void {
-    localStorage.setItem(this.deviceShareStorageKey(signerId), share);
   }
 
   private deviceShareStorageKey(signerId: string): string {

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -20,3 +20,18 @@ export function decodeBytes(bytes: string, encoding: 'base64' | 'base58' | 'hex'
       throw new Error(`Unsupported encoding: ${encoding}`);
   }
 }
+
+export function encodeBytes(bytes: Uint8Array, encoding: 'base64' | 'base58' | 'hex'): string {
+  switch (encoding) {
+    case 'base58':
+      return bs58.encode(bytes);
+    case 'hex':
+      return Array.from(bytes)
+        .map(byte => byte.toString(16).padStart(2, '0'))
+        .join('');
+    case 'base64':
+      return btoa(String.fromCharCode.apply(null, Array.from(bytes)));
+    default:
+      throw new Error(`Unsupported encoding: ${encoding}`);
+  }
+}

--- a/src/tests/test-utils.ts
+++ b/src/tests/test-utils.ts
@@ -11,6 +11,7 @@ import type { EncryptionService } from '../services/encryption';
 import type { FPEService } from '../services/fpe';
 import type { Secp256k1Service } from '../services/secp256k1';
 import type { CryptoKeyService } from '../services/crypto-key';
+import type { DeviceService } from '../services/device';
 /**
  * Creates mock services for testing with proper typing
  */
@@ -24,6 +25,7 @@ export function createMockServices(): MockProxy<XMIFServices> & {
   fpe: MockProxy<FPEService>;
   secp256k1: MockProxy<Secp256k1Service>;
   cryptoKey: MockProxy<CryptoKeyService>;
+  device: MockProxy<DeviceService>;
 } {
   return {
     api: mock<CrossmintApiService>(),
@@ -35,6 +37,7 @@ export function createMockServices(): MockProxy<XMIFServices> & {
     fpe: mock<FPEService>(),
     secp256k1: mock<Secp256k1Service>(),
     cryptoKey: mock<CryptoKeyService>(),
+    device: mock<DeviceService>(),
   };
 }
 


### PR DESCRIPTION
## Description

This PR:
- Cleans up the API surface between Iframe <> Relay <> TEE.
    - https://github.com/Paella-Labs/crossbit-main/pull/19087:
    - https://github.com/Paella-Labs/tee-ts/pull/26
- Handles `signers.crossmint.com` usage across applications
- Handles `signers.crossmint.com` usage across multiple user accounts on the same application
- Adds in-memory auth share caching to speed up signing.
- Improves our testing and adds JSdoc comments to make our auditor's lives easier

![image](https://github.com/user-attachments/assets/d7c8ea95-de7d-45f4-b7de-e8c03bcf4963)

Our approach to enabling different apps and users is to include the `signerId` in the device share local storage key. This `signerId` is obtained when we call the Relay's `GET /v1/devices/key-shares`. With Crossmint's relay, the `signerId` is ``${userId}:${projectId}``.

This PR is too big :) and I'm putting it up with the context that we're beginning the audit on Monday.

## Testing

Added comprehensive unit testing across all key share related code.

Locally, I ran a local copy of the quickstart in the SDK repo using two different API keys. On both sites, I signed and sent a transaction successfully, and in the end device key share's for each application we're stored locally on the device:

<img width="864" alt="Screenshot 2025-05-30 at 10 42 10 PM" src="https://github.com/user-attachments/assets/14ed7a71-8636-46f5-a106-692c04005033" />
