### PR TITLE
Update Encryption Key Signing Curve and Simplify Key Storage (part of WAL-4544)

### DIFF
--- a/src/services/attestation.test.ts
+++ b/src/services/attestation.test.ts
@@ -40,7 +40,7 @@ describe('AttestationService - Security Critical Tests', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockApiService = mock<CrossmintApiService>();
-    service = new AttestationService(mockApiService);
+    service = new AttestationService(mockApiService, '0ade7b12204222a684b6e8e26aa5223f38e90725');
   });
 
   describe('TEE Authenticity Validation - Core Security Function', () => {

--- a/src/services/attestation.test.ts
+++ b/src/services/attestation.test.ts
@@ -32,6 +32,7 @@ vi.mock('./environment', () => ({
 
 const VALID_PUBLIC_KEY =
   'BE2tK2+EUljfdSAvTy9qR7Osk1roVfsB+FDdmz5lfl6ZBLXUUa5I/FQwwh/Hh5QLUwpqAW+EyMDN/X0Ikd4eROuBTCyMNc9gGVmRKKZpCtUv24O5uvRINvswGOZ1ibiYjQ==';
+const VALID_APP_ID = '0ade7b12204222a684b6e8e26aa5223f38e90725';
 
 describe('AttestationService - Security Critical Tests', () => {
   let service: AttestationService;
@@ -40,7 +41,7 @@ describe('AttestationService - Security Critical Tests', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockApiService = mock<CrossmintApiService>();
-    service = new AttestationService(mockApiService, '0ade7b12204222a684b6e8e26aa5223f38e90725');
+    service = new AttestationService(mockApiService, VALID_APP_ID);
   });
 
   describe('TEE Authenticity Validation - Core Security Function', () => {

--- a/src/services/attestation.ts
+++ b/src/services/attestation.ts
@@ -15,7 +15,7 @@ const TEE_REPORT_DATA_HASH = 'SHA-512' as const;
 // RTMR3 calculation constants - Based on DStack TEE implementations
 const INIT_MR = '0'.repeat(96);
 const DSTACK_EVENT_TAG = 0x08000001; // Event type, taken from DStack source code
-const EXPECTED_APP_ID = '0ade7b12204222a684b6e8e26aa5223f38e90725';
+const EXPECTED_APP_ID = 'df4f0ec61f92a8eec754593da9ea9cd939985e9c';
 
 // Event log filtering constants
 const EVENT_LOG_IMR = 3;

--- a/src/services/attestation.ts
+++ b/src/services/attestation.ts
@@ -78,7 +78,7 @@ export class AttestationService extends XMIFService {
 
   constructor(
     private readonly api: CrossmintApiService,
-    private readonly expected_app_id: string
+    private readonly expectedAppId: string
   ) {
     super();
   }
@@ -285,8 +285,8 @@ export class AttestationService extends XMIFService {
   }
 
   private validateEventLogValues(hashes: HashEvent): void {
-    if (hashes.app_id !== this.expected_app_id) {
-      throw new Error(`Invalid app ID: expected ${this.expected_app_id}, got ${hashes.app_id}`);
+    if (hashes.app_id !== this.expectedAppId) {
+      throw new Error(`Invalid app ID: expected ${this.expectedAppId}, got ${hashes.app_id}`);
     }
   }
 

--- a/src/services/attestation.ts
+++ b/src/services/attestation.ts
@@ -15,7 +15,6 @@ const TEE_REPORT_DATA_HASH = 'SHA-512' as const;
 // RTMR3 calculation constants - Based on DStack TEE implementations
 const INIT_MR = '0'.repeat(96);
 const DSTACK_EVENT_TAG = 0x08000001; // Event type, taken from DStack source code
-const EXPECTED_APP_ID = 'df4f0ec61f92a8eec754593da9ea9cd939985e9c';
 
 // Event log filtering constants
 const EVENT_LOG_IMR = 3;
@@ -77,7 +76,10 @@ export class AttestationService extends XMIFService {
   name = 'Attestation Service';
   log_prefix = '[AttestationService]';
 
-  constructor(private readonly api: CrossmintApiService) {
+  constructor(
+    private readonly api: CrossmintApiService,
+    private readonly expected_app_id: string
+  ) {
     super();
   }
 
@@ -283,8 +285,8 @@ export class AttestationService extends XMIFService {
   }
 
   private validateEventLogValues(hashes: HashEvent): void {
-    if (hashes.app_id !== EXPECTED_APP_ID) {
-      throw new Error(`Invalid app ID: expected ${EXPECTED_APP_ID}, got ${hashes.app_id}`);
+    if (hashes.app_id !== this.expected_app_id) {
+      throw new Error(`Invalid app ID: expected ${this.expected_app_id}, got ${hashes.app_id}`);
     }
   }
 

--- a/src/services/encryption-consts.ts
+++ b/src/services/encryption-consts.ts
@@ -15,3 +15,4 @@ export const ECDH_KEY_SPEC: EcKeyGenParams = {
 } as const;
 
 export const IDENTITY_STORAGE_KEY = 'encryption-key-pair';
+export const IDENTITY_KEY_PERMISSIONS: KeyUsage[] = ['deriveBits', 'deriveKey'];

--- a/src/services/encryption-consts.ts
+++ b/src/services/encryption-consts.ts
@@ -1,37 +1,17 @@
-import { z } from 'zod';
-
 export type EncryptionResult<T extends ArrayBuffer | string> = {
   ciphertext: T;
   encapsulatedKey: T;
   publicKey: T;
 };
-export type DecryptOptions = {
-  validateTeeSender: boolean;
-};
-
-export const SerializedPublicKeySchema = z.object({
-  raw: z.string(),
-  algorithm: z.any(),
-});
-export type SerializedPublicKey = z.infer<typeof SerializedPublicKeySchema>;
-
-export const SerializedPrivateKeySchema = z.object({
-  raw: z.any(),
-  usages: z.array(z.custom<KeyUsage>()),
-  algorithm: z.any(),
-});
-export type SerializedPrivateKey = z.infer<typeof SerializedPrivateKeySchema>;
 
 export const AES256_KEY_SPEC: AesKeyGenParams = {
   name: 'AES-GCM' as const,
   length: 256,
 } as const;
+
 export const ECDH_KEY_SPEC: EcKeyGenParams = {
   name: 'ECDH' as const,
-  namedCurve: 'P-384' as const,
+  namedCurve: 'P-256' as const,
 } as const;
 
-export const STORAGE_KEYS = {
-  PRIV_KEY: 'private-key',
-  PUB_KEY: 'public-key',
-} as const;
+export const IDENTITY_STORAGE_KEY = 'encryption-key-pair';

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -30,13 +30,15 @@ export type XMIFServices = {
   device: DeviceService;
 };
 
+const EXPECTED_PHALA_APP_ID = 'df4f0ec61f92a8eec754593da9ea9cd939985e9c';
+
 export const createXMIFServices = () => {
   const eventsService = new EventsService();
   const ed25519Service = new Ed25519Service();
   const encryptionService = new EncryptionService();
   const secp256k1Service = new Secp256k1Service();
   const crossmintApiService = new CrossmintApiService(encryptionService);
-  const attestationService = new AttestationService(crossmintApiService);
+  const attestationService = new AttestationService(crossmintApiService, EXPECTED_PHALA_APP_ID);
   const deviceService = new DeviceService();
   const shardingService = new ShardingService(
     new AuthShareCache(crossmintApiService),


### PR DESCRIPTION
## Description

To match the signing curve of the Phala TEE identity key, this PR updates the main encryption key from p-384 => p-256. This PR also simplifies key storage by using jwk (JSON Web Key) formatting and storing the key under a single property.

Relevant TEE service change: https://github.com/Paella-Labs/tee-ts/pull/32

## Testing 

Tested the flow e2e locally with Phala TEE simulated. Checkout testing section for PR listed above