### PR TITLE
WAL-4939: Infer env from hostname

### DIFF
--- a/src/services/environment.ts
+++ b/src/services/environment.ts
@@ -1,19 +1,13 @@
 export type Environment = 'development' | 'staging' | 'production';
 const DEFAULT_ENVIRONMENT: Environment = 'staging';
 
-export const isEnvironment = (env: unknown): env is Environment => {
-  return ['development', 'staging', 'production'].includes(env as Environment);
-};
-
 export function getEnvironment(): Environment {
   if (window.location.hostname === 'localhost') {
     return 'development';
   }
 
-  const urlParams = new URLSearchParams(window.location.search);
-  const envParam = urlParams.get('environment');
-  if (isEnvironment(envParam)) {
-    return envParam;
+  if (window.location.hostname === 'signers.crossmint.com') {
+    return 'production';
   }
 
   return DEFAULT_ENVIRONMENT;


### PR DESCRIPTION
Remove the URL search param parsing and infer the environment from the hostname.