### PR TITLE
Improve healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:20 AS builder
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
+COPY healthcheck.sh .
 RUN npm install -g pnpm && pnpm install --frozen-lockfile --prod=false
 
 COPY . .
@@ -23,9 +24,11 @@ COPY --from=builder /app/css /usr/share/nginx/html/css
 COPY --from=builder /app/index.html /usr/share/nginx/html/
 COPY --from=builder /app/favicon.ico /usr/share/nginx/html/
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/healthcheck.sh /usr/local/bin/healthcheck.sh
+RUN chmod +x /usr/local/bin/healthcheck.sh
 
 EXPOSE 8080
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD curl -f http://localhost:8080/ || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 CMD healthcheck.sh
 
 # Nginx container uses its own CMD to start, so we don't need to specify one

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20 AS builder
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml  ./
+COPY package.json pnpm-lock.yaml ./
 RUN npm install -g pnpm && pnpm install --frozen-lockfile --prod=false
 
 COPY . .
@@ -15,6 +15,9 @@ RUN pnpm build:prod
 # RUN pnpm generate-sri
 
 FROM nginx:alpine
+
+RUN apk add --no-cache curl
+
 COPY --from=builder /app/dist /usr/share/nginx/html/dist
 COPY --from=builder /app/css /usr/share/nginx/html/css
 COPY --from=builder /app/index.html /usr/share/nginx/html/
@@ -22,5 +25,7 @@ COPY --from=builder /app/favicon.ico /usr/share/nginx/html/
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD curl -f http://localhost:8080/ || exit 1
 
 # Nginx container uses its own CMD to start, so we don't need to specify one

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
 set -e
 
-# Fetch the index.html page
 INDEX_PAGE=$(curl -f http://localhost:8080/)
 
-# Extract the script URL and integrity hash
-# We assume the script tag is on a single line and looks like:
-# <script src="dist/bundle.min.js" integrity="sha384-..."></script>
 SCRIPT_URL=$(echo "$INDEX_PAGE" | grep 'dist/bundle.min.js' | sed -n 's/.*src="\([^"]*\)".*/\1/p')
 INTEGRITY_HASH=$(echo "$INDEX_PAGE" | grep 'dist/bundle.min.js' | sed -n 's/.*integrity="\([^"]*\)".*/\1/p')
 
@@ -16,12 +12,8 @@ if [ -z "$INTEGRITY_HASH" ]; then
     exit 0
 fi
 
-# Fetch the script
 SCRIPT_CONTENT=$(curl -f "http://localhost:8080/$SCRIPT_URL")
 
-# Calculate the script's hash
-# The integrity attribute format is "sha384-HASH"
-# We need to extract the hash algorithm and the base64 hash value
 HASH_ALGO=$(echo "$INTEGRITY_HASH" | cut -d'-' -f1)
 EXPECTED_HASH=$(echo "$INTEGRITY_HASH" | cut -d'-' -f2)
 
@@ -30,7 +22,6 @@ OPENSSL_ALGO=$(echo "$HASH_ALGO" | tr '[:upper:]' '[:lower:]')
 
 CALCULATED_HASH=$(echo -n "$SCRIPT_CONTENT" | openssl dgst -"$OPENSSL_ALGO" -binary | openssl base64 -A)
 
-# Compare the hashes
 if [ "$CALCULATED_HASH" = "$EXPECTED_HASH" ]; then
     echo "SRI check passed for $SCRIPT_URL"
     exit 0

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+# Fetch the index.html page
+INDEX_PAGE=$(curl -f http://localhost:8080/)
+
+# Extract the script URL and integrity hash
+# We assume the script tag is on a single line and looks like:
+# <script src="dist/bundle.min.js" integrity="sha384-..."></script>
+SCRIPT_URL=$(echo "$INDEX_PAGE" | grep 'dist/bundle.min.js' | sed -n 's/.*src="\([^"]*\)".*/\1/p')
+INTEGRITY_HASH=$(echo "$INDEX_PAGE" | grep 'dist/bundle.min.js' | sed -n 's/.*integrity="\([^"]*\)".*/\1/p')
+
+# If there's no integrity hash, we pass the check, as it's not enforced yet
+if [ -z "$INTEGRITY_HASH" ]; then
+    echo "No integrity hash found for $SCRIPT_URL. Health check passed."
+    exit 0
+fi
+
+# Fetch the script
+SCRIPT_CONTENT=$(curl -f "http://localhost:8080/$SCRIPT_URL")
+
+# Calculate the script's hash
+# The integrity attribute format is "sha384-HASH"
+# We need to extract the hash algorithm and the base64 hash value
+HASH_ALGO=$(echo "$INTEGRITY_HASH" | cut -d'-' -f1)
+EXPECTED_HASH=$(echo "$INTEGRITY_HASH" | cut -d'-' -f2)
+
+# Convert sha384 to openssl's algorithm name sha384
+OPENSSL_ALGO=$(echo "$HASH_ALGO" | tr '[:upper:]' '[:lower:]')
+
+CALCULATED_HASH=$(echo -n "$SCRIPT_CONTENT" | openssl dgst -"$OPENSSL_ALGO" -binary | openssl base64 -A)
+
+# Compare the hashes
+if [ "$CALCULATED_HASH" = "$EXPECTED_HASH" ]; then
+    echo "SRI check passed for $SCRIPT_URL"
+    exit 0
+else
+    echo "SRI check failed for $SCRIPT_URL"
+    echo "Expected: $EXPECTED_HASH"
+    echo "Got: $CALCULATED_HASH"
+    exit 1
+fi

--- a/nginx.conf
+++ b/nginx.conf
@@ -84,13 +84,6 @@ server {
         limit_except GET HEAD { deny all; }
     }
     
-    # Health check
-    location = /health {
-        access_log off;
-        add_header Content-Type "application/json";
-        return 200 "{\"status\":\"OK\"}";
-    }
-    
     # Handle 404 errors
     error_page 404 /index.html;
-} 
+}


### PR DESCRIPTION
If the SRI check fails we should mark the deployment as failed so flightcontrol doesn't deploy it breaking the existing solution. This does it.

Tested by checking running the docker image results in a healthy status