### PR TITLE
Update TEE Application Integrity Check For DStack `v0.5.x` (resolves WAL-4898)

### DIFF
--- a/src/services/tee/attestation.test.ts
+++ b/src/services/tee/attestation.test.ts
@@ -348,6 +348,151 @@ describe('AttestationService - Security Critical Tests', () => {
           service.verifyTEEApplicationIntegrity(incompleteLog, 'any-rtmr3')
         ).rejects.toThrow('Missing required application events');
       });
+
+      it('SECURITY: Should reject event logs missing mandatory key_provider', async () => {
+        const logWithoutKeyProvider = [
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest1',
+            event: 'app-id',
+            event_payload: VALID_APP_ID,
+          },
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest2',
+            event: 'compose-hash',
+            event_payload: 'hash',
+          },
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest3',
+            event: 'instance-id',
+            event_payload: 'id',
+          },
+          // Missing key-provider event
+        ];
+
+        await expect(
+          service.verifyTEEApplicationIntegrity(JSON.stringify(logWithoutKeyProvider), VALID_RTMR3)
+        ).rejects.toThrow('Invalid event digest');
+      });
+
+      it('SECURITY: Should validate key_provider has name="kms"', async () => {
+        const validKeyProviderLog = [
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest1',
+            event: 'app-id',
+            event_payload: VALID_APP_ID,
+          },
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest2',
+            event: 'compose-hash',
+            event_payload: 'hash',
+          },
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest3',
+            event: 'instance-id',
+            event_payload: 'id',
+          },
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest4',
+            event: 'key-provider',
+            event_payload: '7b226e616d65223a226b6d73222c226964223a22746573742d6964227d',
+          }, // {"name":"kms","id":"test-id"}
+        ];
+
+        await expect(
+          service.verifyTEEApplicationIntegrity(JSON.stringify(validKeyProviderLog), VALID_RTMR3)
+        ).rejects.toThrow('Invalid event digest');
+      });
+
+      it('SECURITY: Should reject key_provider with invalid name', async () => {
+        const invalidKeyProviderLog = [
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest1',
+            event: 'app-id',
+            event_payload: VALID_APP_ID,
+          },
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest2',
+            event: 'compose-hash',
+            event_payload: 'hash',
+          },
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest3',
+            event: 'instance-id',
+            event_payload: 'id',
+          },
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest4',
+            event: 'key-provider',
+            event_payload: '7b226e616d65223a22696e76616c6964222c226964223a22746573742d6964227d',
+          }, // {"name":"invalid","id":"test-id"}
+        ];
+
+        await expect(
+          service.verifyTEEApplicationIntegrity(JSON.stringify(invalidKeyProviderLog), VALID_RTMR3)
+        ).rejects.toThrow('Invalid event digest');
+      });
+
+      it('SECURITY: Should reject malformed key_provider JSON', async () => {
+        const malformedKeyProviderLog = [
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest1',
+            event: 'app-id',
+            event_payload: VALID_APP_ID,
+          },
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest2',
+            event: 'compose-hash',
+            event_payload: 'hash',
+          },
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest3',
+            event: 'instance-id',
+            event_payload: 'id',
+          },
+          {
+            imr: 3,
+            event_type: 134217729,
+            digest: 'digest4',
+            event: 'key-provider',
+            event_payload: 'invalid-json',
+          },
+        ];
+
+        await expect(
+          service.verifyTEEApplicationIntegrity(
+            JSON.stringify(malformedKeyProviderLog),
+            VALID_RTMR3
+          )
+        ).rejects.toThrow('Invalid event digest');
+      });
     });
   });
 
@@ -466,6 +611,60 @@ describe('AttestationService - Security Critical Tests', () => {
 
       await expect(
         service.verifyTEEApplicationIntegrity(JSON.stringify(keyProviderLog), VALID_RTMR3)
+      ).rejects.toThrow('Invalid event digest');
+    });
+
+    it('should validate key_provider schema with name="kms" requirement', async () => {
+      // Create log with invalid key_provider name but valid structure to test schema validation
+      const logWithInvalidKeyProviderName = [
+        {
+          imr: 3,
+          event_type: 134217729,
+          digest:
+            'f9974020ef507068183313d0ca808e0d1ca9b2d1ad0c61f5784e7157c362c06536f5ddacdad4451693f48fcc72fff624',
+          event: 'system-preparing',
+          event_payload: '',
+        },
+        {
+          imr: 3,
+          event_type: 134217729,
+          digest:
+            '8fb0fe5adbb3a5038e382aa1c4f5878ffa22b0671b3fba3ca9181c5a3e3b5fb47a33ed4fc8f63fcaf1a949a53acef0fa',
+          event: 'app-id',
+          event_payload: VALID_APP_ID,
+        },
+        {
+          imr: 3,
+          event_type: 134217729,
+          digest:
+            'ba99db40bbcf5a0c855ee6233f2bb0581d408cf430a98cea5233daf8e21e6483419c1bb9d2c0057f5e9185a5a2bc0e2f',
+          event: 'compose-hash',
+          event_payload: '1b41d549eeb909955c5753df9064b2db28b99b70c1adc00a14c49825f104ea75',
+        },
+        {
+          imr: 3,
+          event_type: 134217729,
+          digest:
+            'fdea52c2b3479345247a2d0a05a8e36caee77d6a35aa896d86c5724f75147541966dcebbafa7724af04ce8d855aef2b5',
+          event: 'instance-id',
+          event_payload: '396554b3487ed9549b2e57435574b1cc0f959aef',
+        },
+        {
+          imr: 3,
+          event_type: 134217729,
+          digest:
+            '98bd7e6bd3952720b65027fd494834045d06b4a714bf737a06b874638b3ea00ff402f7f583e3e3b05e921c8570433ac6',
+          event: 'key-provider',
+          event_payload: '7b226e616d65223a22696e76616c6964222c226964223a22746573742d6964227d', // {"name":"invalid","id":"test-id"}
+        },
+      ];
+
+      // Should fail during digest validation because the payload doesn't match the real digest
+      await expect(
+        service.verifyTEEApplicationIntegrity(
+          JSON.stringify(logWithInvalidKeyProviderName),
+          VALID_RTMR3
+        )
       ).rejects.toThrow('Invalid event digest');
     });
   });

--- a/src/services/tee/attestation.test.ts
+++ b/src/services/tee/attestation.test.ts
@@ -21,9 +21,13 @@ vi.mock('@phala/dcap-qvl-web/dcap-qvl-web_bg.wasm', () => ({
   default: 'mock-wasm-buffer',
 }));
 
-vi.mock('./environment', () => ({
-  isDevelopment: () => false,
-}));
+vi.mock('../api', async () => {
+  const actual = await vi.importActual('../api');
+  return {
+    ...actual,
+    isDevelopment: () => false,
+  };
+});
 
 const VALID_PUBLIC_KEY =
   'BMbRE3oZ8rxCzkPYntr/gApxZO2nO1T44HCwLDokZOy/y3/3NW/VhVFLrUSKjohgAQFk6wckzs50HGmn+IAwVEk=';

--- a/src/services/tee/attestation.ts
+++ b/src/services/tee/attestation.ts
@@ -105,10 +105,10 @@ export class AttestationService extends CrossmintFrameService {
 
   async init() {
     try {
-      // if (isDevelopment()) {
-      //   this.publicKey = await this.getPublicKeyDevMode();
-      //   return;
-      // }
+      if (isDevelopment()) {
+        this.publicKey = await this.getPublicKeyDevMode();
+        return;
+      }
 
       const attestation = await this.api.getAttestation();
       this.log('TEE attestation document fetched');
@@ -189,7 +189,7 @@ export class AttestationService extends CrossmintFrameService {
    * 4. Comparing replayed RTMR3 against the value reported by the TEE hardware
    * 5. Validating that the application ID matches the expected authorized application
    *
-   * The validation approach follows the reference implementation provided by the Phala team:
+   * The validation approach follows the reference implementation provided by the Dstack authors
    * https://github.com/Dstack-TEE/dstack-examples/blob/main/attestation/rtmr3-based/verify.py
    *
    * Only RTMR3 events are validated, as other IMR registers may have different validation rules.


### PR DESCRIPTION
This PR updates our application integrity checks via `rtmr3` replays to account for changes going from dstack version `0.3.x` to `0.5.x`. Specifically it:
- Updates `rtmr3` calculation according to a new sample provided by the phala team: https://github.com/Dstack-TEE/dstack-examples/blob/main/attestation/rtmr3-based/verify.py
- Considers `key_provider` as part of the application integrity check, ensuring TEE instances must use onchain KMS.

After this lands, pending an SDK release from phala to help construct the `app-compose` file in advance of deployment, we still need to add `compose-hash` checks.